### PR TITLE
fix: add sizes prop to Image with fill in ProductList

### DIFF
--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -124,6 +124,7 @@ export default function ProductList() {
                   src={product.image}
                   alt={product.name}
                   fill
+                  sizes="(min-width: 768px) 25vw, (min-width: 640px) 33vw, 50vw"
                   className="object-contain p-3"
                 />
                 <div className="absolute bottom-2 right-2 bg-card/90 px-2 py-[3px] rounded-[4px]">


### PR DESCRIPTION
Closes #79

## Cambio

Agregado `sizes` prop en el componente `<Image fill>` de `ProductList.tsx`:

```tsx
sizes="(min-width: 768px) 25vw, (min-width: 640px) 33vw, 50vw"
```

Coincide con el grid de productos:
- `md+` (≥768px) → 4 columnas → `25vw`
- `sm` (≥640px) → 3 columnas → `33vw`
- mobile → 2 columnas → `50vw`

Next.js ahora descargará el tamaño de imagen óptimo para cada breakpoint en lugar de siempre solicitar `3840px`.