### PR TITLE
fix(proxy): rename middleware export to proxy and pin Node.js to 20.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": "20.x"
   },
   "dependencies": {
     "@playwright/test": "^1.57.0",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -34,7 +34,7 @@ function applySecurityHeaders(response: NextResponse): NextResponse {
   return response;
 }
 
-export function middleware(request: NextRequest): NextResponse {
+export function proxy(request: NextRequest): NextResponse {
   const apiKey = request.headers.get('x-api-key');
   if (!apiKey || apiKey !== process.env.API_SECRET_KEY) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });


### PR DESCRIPTION
Closes #93

## Summary

- **Build fix**: `src/proxy.ts` exportaba `middleware` en lugar de `proxy`, causando que Turbopack fallara con _"Proxy is missing expected function export name"_ en cada deploy a Vercel
- **Warning fix**: `engines.node` era `>=22.13.0` (open range), disparando un warning de Vercel sobre auto-upgrade a versiones mayores futuras — fijado a `20.x` según los docs oficiales de Next.js 16 (mínimo: 20.9+)

## Root cause

Commit `f4b85d3` renombró el archivo `middleware.ts` → `proxy.ts` siguiendo la convención de Next.js 16, pero olvidó renombrar el export de la función de `middleware` a `proxy`.

## Test plan

- [ ] Vercel build completa sin el error _"Proxy is missing expected function export name"_
- [ ] Vercel build completa sin el warning de versión de Node.js
- [ ] Rate limiting y security headers siguen funcionando en rutas `/api/*`