### PR TITLE
fix(scrapers): migrate Cetrogar from Magento/Cheerio to VTEX Intelligent Search

### DIFF
--- a/src/scrapers/cetrogar/index.ts
+++ b/src/scrapers/cetrogar/index.ts
@@ -1,57 +1,7 @@
-import { load } from "cheerio";
-import { Product } from "@/types/product";
 import { StoreNamesEnum } from "@/enums/stores.enum";
-import { httpClient } from "@/platform/http";
+import { createVtexScraper } from "@/platform/vtex/helpers";
 
-export async function scrapeCetrogar(query: string): Promise<Product[]> {
-  const url = `https://www.cetrogar.com.ar/catalogsearch/result/?q=${query}`;
-  try {
-    const { data } = await httpClient.get(url);
-    const $ = load(data);
-
-    const products: Product[] = $(".item.product.product-item")
-      .map((_, item) => {
-        const name = $(item)
-          .find(".product.name.product-item-name")
-          .text()
-          .trim();
-        const price = $(item)
-          .find("span[data-price-type='finalPrice']")
-          .text()
-          .trim()
-          .replaceAll(/[^\d,.-]/g, "")
-          .replaceAll(".", "")
-          .replace(",", ".");
-
-        const imageStyle = $(item).find(".product-image-photo").attr("style");
-        const imageUrlMatch = /url\(['"]?(.*?)['"]?\)/.exec(imageStyle ?? "");
-        const imageUrl = imageUrlMatch
-          ? imageUrlMatch[1]
-          : "https://placehold.co/300x200";
-        const url = $(item).find("a").attr("href");
-
-        const installmentText = $(item)
-          .find(".installment-info > span.value > span.installment-count")
-          .text()
-          .trim();
-        const installment = installmentText ? Number(installmentText) : 0;
-
-        return {
-          name,
-          price: Number(price),
-          from: StoreNamesEnum.CETROGAR,
-          image: imageUrl,
-          url,
-          brand: "Unknown",
-          installment,
-        };
-      })
-      .get();
-
-    if (!products) return [];
-    return products;
-  } catch (error) {
-    console.error("Error fetching products from Cetrogar:", error);
-    return [];
-  }
-}
+export const scrapeCetrogar = createVtexScraper(
+  "https://www.cetrogar.com.ar",
+  StoreNamesEnum.CETROGAR,
+);


### PR DESCRIPTION
## Summary

- Cetrogar migrated their storefront from Magento to VTEX FastStore
- Old scraper used Cheerio to parse `/catalogsearch/result/?q=` — now returns 404 and silently yields `[]`
- Replaces 57-line scraper with `createVtexScraper` factory (3 lines), matching Frávega, Naldo, OnCity and Carrefour

## Test plan

- [ ] Run `npm test` — 120 tests passing
- [ ] Manual: search "smart tv" in dev — Cetrogar results appear

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)