### PR TITLE
feat(ui): full filter system — price range, CSI, sort, responsive panel

### DIFF
--- a/src/components/CSIFilter.stories.tsx
+++ b/src/components/CSIFilter.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { CSIFilter } from "./CSIFilter";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+import { useEffect } from "react";
+
+const meta = {
+  title: "Components/CSIFilter",
+  component: CSIFilter,
+  tags: ["autodocs"],
+} satisfies Meta<typeof CSIFilter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function CSIWrapper({ selectedCSI, Story }: Readonly<{ selectedCSI: number | null; Story: React.ComponentType }>) {
+  useEffect(() => {
+    useProductsStore.setState({ selectedCSI });
+  }, [selectedCSI]);
+  return <Story />;
+}
+
+function withCSI(selectedCSI: number | null) {
+  const Decorator = (Story: React.ComponentType) => (
+    <CSIWrapper selectedCSI={selectedCSI} Story={Story} />
+  );
+  Decorator.displayName = `WithCSI(${selectedCSI})`;
+  return Decorator;
+}
+
+export const Default: Story = {
+  decorators: [withCSI(null)],
+};
+
+export const Six: Story = {
+  decorators: [withCSI(6)],
+};
+
+export const Twelve: Story = {
+  decorators: [withCSI(12)],
+};
+
+export const EighteenPlus: Story = {
+  decorators: [withCSI(18)],
+};

--- a/src/components/CSIFilter.tsx
+++ b/src/components/CSIFilter.tsx
@@ -1,0 +1,38 @@
+"use client";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+import { cn } from "@/lib/utils";
+
+const OPTIONS: { label: string; value: number | null }[] = [
+  { label: "Cualquiera", value: null },
+  { label: "6 CSI", value: 6 },
+  { label: "12 CSI", value: 12 },
+  { label: "18+ CSI", value: 18 },
+];
+
+export function CSIFilter() {
+  const selectedCSI = useProductsStore((s) => s.selectedCSI);
+  const setSelectedCSI = useProductsStore((s) => s.setSelectedCSI);
+
+  return (
+    <div className="flex items-center gap-1" role="group" aria-label="Cuotas sin interés">
+      {OPTIONS.map(({ label, value }) => {
+        const active = selectedCSI === value;
+        return (
+          <button
+            key={label}
+            onClick={() => setSelectedCSI(value)}
+            className={cn(
+              "h-8 px-3 text-sm rounded-full border transition-colors",
+              active
+                ? "bg-primary text-primary-foreground border-primary"
+                : "bg-background text-foreground border-border hover:border-primary"
+            )}
+            aria-pressed={active}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/FilterPanel.stories.tsx
+++ b/src/components/FilterPanel.stories.tsx
@@ -23,9 +23,9 @@ const BASE_STATE = {
   brands: ["Todas", "Samsung", "LG"],
   selectedBrand: "Todas",
   selectedStore: "Todas",
-  priceMin: null,
-  priceMax: null,
-  selectedCSI: null,
+  priceMin: null as number | null,
+  priceMax: null as number | null,
+  selectedCSI: null as number | null,
   sortBy: "price_asc" as const,
 };
 

--- a/src/components/FilterPanel.stories.tsx
+++ b/src/components/FilterPanel.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { FilterPanel } from "./FilterPanel";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+import { StoreNamesEnum } from "@/enums/stores.enum";
+import { useEffect } from "react";
+
+const meta = {
+  title: "Components/FilterPanel",
+  component: FilterPanel,
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof FilterPanel>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const BASE_STATE = {
+  products: [
+    { name: "TV Samsung 55", brand: "Samsung", price: 150_000, from: StoreNamesEnum.FRAVEGA, image: "", url: "#", installment: 12 },
+    { name: "TV LG 50", brand: "LG", price: 120_000, from: StoreNamesEnum.CARREFOUR, image: "", url: "#", installment: 6 },
+  ],
+  stores: [StoreNamesEnum.FRAVEGA, StoreNamesEnum.CARREFOUR],
+  brands: ["Todas", "Samsung", "LG"],
+  selectedBrand: "Todas",
+  selectedStore: "Todas",
+  priceMin: null,
+  priceMax: null,
+  selectedCSI: null,
+  sortBy: "price_asc" as const,
+};
+
+function WithProductsWrapper({ stateOverrides, Story }: Readonly<{
+  stateOverrides?: Partial<typeof BASE_STATE>;
+  Story: React.ComponentType;
+}>) {
+  useEffect(() => {
+    useProductsStore.setState({ ...BASE_STATE, ...stateOverrides });
+  }, [stateOverrides]);
+  return <div className="p-4"><Story /></div>;
+}
+
+function withProducts(stateOverrides?: Partial<typeof BASE_STATE>) {
+  const Decorator = (Story: React.ComponentType) => (
+    <WithProductsWrapper stateOverrides={stateOverrides} Story={Story} />
+  );
+  Decorator.displayName = "WithProducts";
+  return Decorator;
+}
+
+export const Desktop: Story = {
+  decorators: [withProducts()],
+  parameters: { viewport: { defaultViewport: "desktop" } },
+};
+
+export const WithActiveFilters: Story = {
+  decorators: [withProducts({ priceMin: 100_000, priceMax: 200_000, selectedCSI: 12 })],
+};

--- a/src/components/FilterPanel.tsx
+++ b/src/components/FilterPanel.tsx
@@ -1,0 +1,118 @@
+"use client";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+import { ALL } from "@/features/price-search/constants";
+import { StoreFilter } from "@/components/StoreFilter";
+import BrandFilter from "@/components/BrandFilter";
+import { PriceRangeFilter } from "@/components/PriceRangeFilter";
+import { CSIFilter } from "@/components/CSIFilter";
+import { SortControl } from "@/components/SortControl";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+function useActiveFilterCount() {
+  const selectedStore = useProductsStore((s) => s.selectedStore);
+  const selectedBrand = useProductsStore((s) => s.selectedBrand);
+  const priceMin = useProductsStore((s) => s.priceMin);
+  const priceMax = useProductsStore((s) => s.priceMax);
+  const selectedCSI = useProductsStore((s) => s.selectedCSI);
+
+  return [
+    selectedStore !== ALL,
+    selectedBrand !== ALL,
+    priceMin !== null,
+    priceMax !== null,
+    selectedCSI !== null,
+  ].filter(Boolean).length;
+}
+
+function FiltersContent() {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Tienda</span>
+        <StoreFilter />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Marca</span>
+        <BrandFilter />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Precio</span>
+        <PriceRangeFilter />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Cuotas sin interés</span>
+        <CSIFilter />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Ordenar</span>
+        <SortControl />
+      </div>
+    </div>
+  );
+}
+
+export function FilterPanel() {
+  const activeCount = useActiveFilterCount();
+  const clearFilters = useProductsStore((s) => s.clearFilters);
+  const products = useProductsStore((s) => s.products);
+
+  if (products.length === 0) return null;
+
+  return (
+    <>
+      {/* Desktop / Tablet — horizontal row */}
+      <div className="hidden sm:flex items-center gap-3 flex-wrap">
+        <StoreFilter />
+        <BrandFilter />
+        <PriceRangeFilter />
+        <CSIFilter />
+        <SortControl />
+        {activeCount > 0 && (
+          <button
+            onClick={clearFilters}
+            className="text-sm text-muted-foreground underline hover:text-foreground transition-colors"
+          >
+            Limpiar ({activeCount})
+          </button>
+        )}
+      </div>
+
+      {/* Mobile — trigger + bottom sheet */}
+      <div className="sm:hidden flex items-center gap-2">
+        <Dialog>
+          <DialogTrigger asChild>
+            <button className="h-9 px-4 text-sm rounded-full border border-border bg-background text-foreground flex items-center gap-2">
+              Filtros
+              {activeCount > 0 && (
+                <span className="flex items-center justify-center size-5 rounded-full bg-primary text-primary-foreground text-xs font-bold">
+                  {activeCount}
+                </span>
+              )}
+            </button>
+          </DialogTrigger>
+          <DialogContent className="sm:max-w-sm">
+            <DialogHeader>
+              <DialogTitle>Filtros</DialogTitle>
+            </DialogHeader>
+            <FiltersContent />
+            {activeCount > 0 && (
+              <button
+                onClick={clearFilters}
+                className="mt-2 text-sm text-muted-foreground underline hover:text-foreground transition-colors"
+              >
+                Limpiar filtros ({activeCount})
+              </button>
+            )}
+          </DialogContent>
+        </Dialog>
+        <SortControl />
+      </div>
+    </>
+  );
+}

--- a/src/components/PriceRangeFilter.stories.tsx
+++ b/src/components/PriceRangeFilter.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PriceRangeFilter } from "./PriceRangeFilter";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+import { useEffect } from "react";
+
+const meta = {
+  title: "Components/PriceRangeFilter",
+  component: PriceRangeFilter,
+  tags: ["autodocs"],
+} satisfies Meta<typeof PriceRangeFilter>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type PriceState = { priceMin?: number | null; priceMax?: number | null };
+
+function PriceStateWrapper({ state, Story }: Readonly<{ state: PriceState; Story: React.ComponentType }>) {
+  useEffect(() => {
+    useProductsStore.setState({ priceMin: state.priceMin ?? null, priceMax: state.priceMax ?? null });
+  }, [state]);
+  return <Story />;
+}
+
+function withPriceState(state: PriceState) {
+  const Decorator = (Story: React.ComponentType) => (
+    <PriceStateWrapper state={state} Story={Story} />
+  );
+  Decorator.displayName = `WithPriceState`;
+  return Decorator;
+}
+
+export const Default: Story = {
+  decorators: [withPriceState({})],
+};
+
+export const WithMinSet: Story = {
+  decorators: [withPriceState({ priceMin: 100_000 })],
+};
+
+export const WithRange: Story = {
+  decorators: [withPriceState({ priceMin: 100_000, priceMax: 300_000 })],
+};

--- a/src/components/PriceRangeFilter.tsx
+++ b/src/components/PriceRangeFilter.tsx
@@ -1,0 +1,33 @@
+"use client";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+
+export function PriceRangeFilter() {
+  const priceMin = useProductsStore((s) => s.priceMin);
+  const priceMax = useProductsStore((s) => s.priceMax);
+  const setPriceMin = useProductsStore((s) => s.setPriceMin);
+  const setPriceMax = useProductsStore((s) => s.setPriceMax);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <input
+        type="number"
+        min={0}
+        placeholder="Desde $"
+        value={priceMin ?? ""}
+        onChange={(e) => setPriceMin(e.target.value ? Number(e.target.value) : null)}
+        className="w-24 h-8 px-2 text-sm rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        aria-label="Precio mínimo"
+      />
+      <span className="text-muted-foreground text-sm">—</span>
+      <input
+        type="number"
+        min={0}
+        placeholder="Hasta $"
+        value={priceMax ?? ""}
+        onChange={(e) => setPriceMax(e.target.value ? Number(e.target.value) : null)}
+        className="w-24 h-8 px-2 text-sm rounded-md border border-border bg-background text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        aria-label="Precio máximo"
+      />
+    </div>
+  );
+}

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -1,17 +1,22 @@
-﻿"use client";
+"use client";
 import Image from "next/image";
 import Link from "next/link";
 import { imageLoader } from "@/features/price-search/image-loader";
 import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
-import { ALL } from "@/features/price-search/constants";
 import { loadingMessages } from "@/features/price-search/loading-messages";
-import { capitalize } from "@/lib/capitalize";
 import { useEffect, useState } from "react";
 import { EmptyState } from "./EmptyState";
 
 const ITEMS_PER_PAGE = 12;
 
 const SKELETON_KEYS = ["s0", "s1", "s2", "s3", "s4", "s5", "s6", "s7"] as const;
+
+const SORT_LABELS: Record<string, string> = {
+  price_asc: "Menor precio",
+  price_desc: "Mayor precio",
+  installments_desc: "Más cuotas",
+  best_installment: "Mejor cuota",
+};
 
 function SkeletonCard() {
   return (
@@ -29,18 +34,21 @@ function SkeletonCard() {
 }
 
 export default function ProductList() {
-  const { products, selectedBrand, selectedStore, isLoading } =
-    useProductsStore();
+  const products = useProductsStore((s) => s.products);
+  const filteredProducts = useProductsStore((s) => s.filteredProducts);
+  const isLoading = useProductsStore((s) => s.isLoading);
+  const sortBy = useProductsStore((s) => s.sortBy);
+
   const [loadingMessage, setLoadingMessage] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
-  const [prevBrand, setPrevBrand] = useState(selectedBrand);
-  const [prevStore, setPrevStore] = useState(selectedStore);
-  const [prevProducts, setPrevProducts] = useState(products);
+  const [prevSortBy, setPrevSortBy] = useState(sortBy);
+  const [prevProductsRef, setPrevProductsRef] = useState(products);
 
-  if (prevBrand !== selectedBrand || prevStore !== selectedStore || prevProducts !== products) {
-    setPrevBrand(selectedBrand);
-    setPrevStore(selectedStore);
-    setPrevProducts(products);
+  const visible = filteredProducts();
+
+  if (prevSortBy !== sortBy || prevProductsRef !== products) {
+    setPrevSortBy(sortBy);
+    setPrevProductsRef(products);
     setCurrentPage(1);
   }
 
@@ -56,20 +64,8 @@ export default function ProductList() {
     }
   }, [isLoading]);
 
-  let filteredProducts = products;
-  if (selectedBrand !== ALL) {
-    filteredProducts = filteredProducts.filter(
-      (product) => capitalize(product.brand) === selectedBrand,
-    );
-  }
-  if (selectedStore !== ALL) {
-    filteredProducts = filteredProducts.filter(
-      (product) => product.from === selectedStore,
-    );
-  }
-
-  const totalPages = Math.ceil(filteredProducts.length / ITEMS_PER_PAGE);
-  const paginatedProducts = filteredProducts.slice(
+  const totalPages = Math.ceil(visible.length / ITEMS_PER_PAGE);
+  const paginatedProducts = visible.slice(
     (currentPage - 1) * ITEMS_PER_PAGE,
     currentPage * ITEMS_PER_PAGE,
   );
@@ -89,22 +85,21 @@ export default function ProductList() {
     );
   }
 
-  if (filteredProducts.length === 0 && products.length > 0) {
+  if (visible.length === 0 && products.length > 0) {
     return <EmptyState />;
   }
 
-  if (filteredProducts.length === 0) return null;
+  if (visible.length === 0) return null;
 
   return (
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <span className="text-xs sm:text-sm font-medium text-foreground">
-          {filteredProducts.length} resultado
-          {filteredProducts.length === 1 ? "" : "s"}
+          {visible.length} resultado{visible.length === 1 ? "" : "s"}
         </span>
         <span className="text-xs sm:text-sm font-normal text-muted-foreground">
           <span className="sm:hidden">Precio ↕</span>
-          <span className="hidden sm:inline">Ordenar: Menor precio ↕</span>
+          <span className="hidden sm:inline">Ordenar: {SORT_LABELS[sortBy]} ↕</span>
         </span>
       </div>
 
@@ -149,8 +144,8 @@ export default function ProductList() {
                     {product.brand}
                   </span>
                   {product.installment ? (
-                    <span className="bg-orange-700 rounded-md px-2 py-[3px] text-xs font-medium text-white">
-                      {product.installment}x sin interes
+                    <span className="bg-orange-500 rounded-md px-2 py-[3px] text-xs font-medium text-white">
+                      {product.installment} CSI
                     </span>
                   ) : null}
                 </div>

--- a/src/components/SortControl.stories.tsx
+++ b/src/components/SortControl.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { SortControl } from "./SortControl";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+import { useEffect } from "react";
+
+const meta = {
+  title: "Components/SortControl",
+  component: SortControl,
+  tags: ["autodocs"],
+} satisfies Meta<typeof SortControl>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+type SortBy = "price_asc" | "price_desc" | "installments_desc" | "best_installment";
+
+function SortWrapper({ sortBy, Story }: Readonly<{ sortBy: SortBy; Story: React.ComponentType }>) {
+  useEffect(() => {
+    useProductsStore.setState({ sortBy });
+  }, [sortBy]);
+  return <Story />;
+}
+
+function withSort(sortBy: SortBy) {
+  const Decorator = (Story: React.ComponentType) => (
+    <SortWrapper sortBy={sortBy} Story={Story} />
+  );
+  Decorator.displayName = `WithSort(${sortBy})`;
+  return Decorator;
+}
+
+export const PriceAsc: Story = {
+  decorators: [withSort("price_asc")],
+};
+
+export const PriceDesc: Story = {
+  decorators: [withSort("price_desc")],
+};
+
+export const InstallmentsDesc: Story = {
+  decorators: [withSort("installments_desc")],
+};
+
+export const BestInstallment: Story = {
+  decorators: [withSort("best_installment")],
+};

--- a/src/components/SortControl.tsx
+++ b/src/components/SortControl.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { useProductsStore } from "@/features/price-search/hooks/useProductsStore";
+
+const OPTIONS = [
+  { value: "price_asc", label: "Menor precio" },
+  { value: "price_desc", label: "Mayor precio" },
+  { value: "installments_desc", label: "Más cuotas" },
+  { value: "best_installment", label: "Mejor cuota" },
+] as const;
+
+export function SortControl() {
+  const sortBy = useProductsStore((s) => s.sortBy);
+  const setSortBy = useProductsStore((s) => s.setSortBy);
+
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-sm text-muted-foreground whitespace-nowrap">Ordenar por</span>
+      <select
+        value={sortBy}
+        onChange={(e) => setSortBy(e.target.value as typeof sortBy)}
+        className="h-8 px-2 text-sm rounded-md border border-border bg-background text-foreground focus:outline-none focus:ring-1 focus:ring-primary"
+        aria-label="Ordenar resultados"
+      >
+        {OPTIONS.map(({ value, label }) => (
+          <option key={value} value={value}>
+            {label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/features/price-search/__tests__/useProductsStore.filters.test.ts
+++ b/src/features/price-search/__tests__/useProductsStore.filters.test.ts
@@ -1,0 +1,163 @@
+import { useProductsStore } from "../hooks/useProductsStore";
+import { StoreNamesEnum } from "@/enums/stores.enum";
+import { ALL } from "../constants";
+
+jest.mock("../api", () => ({ getProduct: jest.fn() }));
+
+const p = (
+  name: string,
+  brand: string,
+  price: number,
+  from: StoreNamesEnum,
+  installment = 0
+) => ({ name, brand, price, from, image: "", url: "", installment });
+
+const BASE_PRODUCTS = [
+  p("TV Samsung 55", "Samsung", 150_000, StoreNamesEnum.FRAVEGA, 12),
+  p("TV LG 50", "LG", 120_000, StoreNamesEnum.CARREFOUR, 6),
+  p("TV Sony 65", "Sony", 300_000, StoreNamesEnum.FRAVEGA, 18),
+  p("TV Samsung 43", "Samsung", 90_000, StoreNamesEnum.CARREFOUR, 0),
+];
+
+beforeEach(() => {
+  useProductsStore.setState({
+    products: BASE_PRODUCTS,
+    productSearched: "tv",
+    brands: [ALL, "Samsung", "Lg", "Sony"],
+    selectedBrand: ALL,
+    selectedStore: ALL,
+    stores: [],
+    isLoading: false,
+    priceMin: null,
+    priceMax: null,
+    selectedCSI: null,
+    sortBy: "price_asc",
+  });
+});
+
+describe("filteredProducts", () => {
+  it("no filters → returns all products sorted by price_asc", () => {
+    const { filteredProducts } = useProductsStore.getState();
+    const prices = filteredProducts().map((p) => p.price);
+    expect(prices).toEqual([90_000, 120_000, 150_000, 300_000]);
+  });
+
+  it("priceMin filters out products below threshold", () => {
+    useProductsStore.setState({ priceMin: 130_000 });
+    const { filteredProducts } = useProductsStore.getState();
+    const prices = filteredProducts().map((p) => p.price);
+    expect(prices).toEqual([150_000, 300_000]);
+  });
+
+  it("priceMax filters out products above threshold", () => {
+    useProductsStore.setState({ priceMax: 140_000 });
+    const { filteredProducts } = useProductsStore.getState();
+    const prices = filteredProducts().map((p) => p.price);
+    expect(prices).toEqual([90_000, 120_000]);
+  });
+
+  it("priceMin + priceMax applies range", () => {
+    useProductsStore.setState({ priceMin: 100_000, priceMax: 200_000 });
+    const { filteredProducts } = useProductsStore.getState();
+    const prices = filteredProducts().map((p) => p.price);
+    expect(prices).toEqual([120_000, 150_000]);
+  });
+
+  it("selectedCSI=6 shows only products with installment >= 6", () => {
+    useProductsStore.setState({ selectedCSI: 6 });
+    const { filteredProducts } = useProductsStore.getState();
+    const results = filteredProducts();
+    expect(results.every((p) => (p.installment ?? 0) >= 6)).toBe(true);
+    expect(results.map((p) => p.name)).not.toContain("TV Samsung 43");
+  });
+
+  it("selectedCSI=18 shows only products with installment >= 18", () => {
+    useProductsStore.setState({ selectedCSI: 18 });
+    const { filteredProducts } = useProductsStore.getState();
+    const results = filteredProducts();
+    expect(results).toHaveLength(1);
+    expect(results[0].name).toBe("TV Sony 65");
+  });
+
+  it("selectedCSI=null (Cualquiera) shows all products", () => {
+    useProductsStore.setState({ selectedCSI: null });
+    const { filteredProducts } = useProductsStore.getState();
+    expect(filteredProducts()).toHaveLength(4);
+  });
+
+  it("sortBy=price_desc sorts descending", () => {
+    useProductsStore.setState({ sortBy: "price_desc" });
+    const { filteredProducts } = useProductsStore.getState();
+    const prices = filteredProducts().map((p) => p.price);
+    expect(prices).toEqual([300_000, 150_000, 120_000, 90_000]);
+  });
+
+  it("sortBy=installments_desc sorts by installment count descending", () => {
+    useProductsStore.setState({ sortBy: "installments_desc" });
+    const { filteredProducts } = useProductsStore.getState();
+    const installments = filteredProducts().map((p) => p.installment);
+    expect(installments[0]).toBe(18);
+    expect(installments[1]).toBe(12);
+  });
+
+  it("sortBy=best_installment sorts by price/installment ascending (skips 0)", () => {
+    useProductsStore.setState({ sortBy: "best_installment" });
+    const { filteredProducts } = useProductsStore.getState();
+    const results = filteredProducts();
+    const withCSI = results.filter((p) => (p.installment ?? 0) > 0);
+    for (let i = 1; i < withCSI.length; i++) {
+      const prev = withCSI[i - 1].price! / withCSI[i - 1].installment!;
+      const curr = withCSI[i].price! / withCSI[i].installment!;
+      expect(prev).toBeLessThanOrEqual(curr);
+    }
+  });
+
+  it("selectedBrand filter still works alongside new filters", () => {
+    useProductsStore.setState({ selectedBrand: "Samsung", priceMax: 160_000 });
+    const { filteredProducts } = useProductsStore.getState();
+    const results = filteredProducts();
+    expect(results.every((p) => p.brand === "Samsung")).toBe(true);
+    expect(results.every((p) => (p.price ?? 0) <= 160_000)).toBe(true);
+  });
+});
+
+describe("setPriceMin / setPriceMax / setSelectedCSI / setSortBy", () => {
+  it("setPriceMin updates priceMin", () => {
+    useProductsStore.getState().setPriceMin(50_000);
+    expect(useProductsStore.getState().priceMin).toBe(50_000);
+  });
+
+  it("setPriceMax updates priceMax", () => {
+    useProductsStore.getState().setPriceMax(200_000);
+    expect(useProductsStore.getState().priceMax).toBe(200_000);
+  });
+
+  it("setSelectedCSI updates selectedCSI", () => {
+    useProductsStore.getState().setSelectedCSI(12);
+    expect(useProductsStore.getState().selectedCSI).toBe(12);
+  });
+
+  it("setSortBy updates sortBy", () => {
+    useProductsStore.getState().setSortBy("price_desc");
+    expect(useProductsStore.getState().sortBy).toBe("price_desc");
+  });
+});
+
+describe("clearFilters", () => {
+  it("resets all new filters to defaults", () => {
+    useProductsStore.setState({
+      priceMin: 100_000,
+      priceMax: 200_000,
+      selectedCSI: 12,
+      sortBy: "price_desc",
+    });
+
+    useProductsStore.getState().clearFilters();
+
+    const state = useProductsStore.getState();
+    expect(state.priceMin).toBeNull();
+    expect(state.priceMax).toBeNull();
+    expect(state.selectedCSI).toBeNull();
+    expect(state.sortBy).toBe("price_asc");
+  });
+});

--- a/src/features/price-search/hooks/useProductsStore.ts
+++ b/src/features/price-search/hooks/useProductsStore.ts
@@ -6,6 +6,8 @@ import { capitalize } from "@/lib/capitalize";
 import { Product } from "@/types/product";
 import { create } from "zustand";
 
+type SortBy = "price_asc" | "price_desc" | "installments_desc" | "best_installment";
+
 interface State {
   getProducts: (productName: string) => Promise<void>;
   products: Product[];
@@ -19,6 +21,16 @@ interface State {
   setIsLoading: (loading: boolean) => void;
   setStores: () => void;
   stores: StoreNamesEnum[];
+  priceMin: number | null;
+  priceMax: number | null;
+  selectedCSI: number | null;
+  sortBy: SortBy;
+  setPriceMin: (v: number | null) => void;
+  setPriceMax: (v: number | null) => void;
+  setSelectedCSI: (v: number | null) => void;
+  setSortBy: (v: SortBy) => void;
+  clearFilters: () => void;
+  filteredProducts: () => Product[];
 }
 
 export const useProductsStore = create<State>((set, get) => ({
@@ -31,7 +43,6 @@ export const useProductsStore = create<State>((set, get) => ({
   getProducts: async (productName: string) => {
     const products = await getProduct(productName);
     const productsUpdated = updateUnknownBrands(products);
-    // Ordenar los productos por menor precio
     productsUpdated.sort((a: Product, b: Product) => {
       const priceA = a.price ?? Infinity;
       const priceB = b.price ?? Infinity;
@@ -42,9 +53,7 @@ export const useProductsStore = create<State>((set, get) => ({
       capitalize(product.brand)
     );
     const uniqueBrands = Array.from(new Set(brands));
-
     uniqueBrands.sort((a, b) => a.localeCompare(b));
-
     uniqueBrands.unshift(ALL);
 
     set(() => ({
@@ -67,5 +76,41 @@ export const useProductsStore = create<State>((set, get) => ({
     const stores = filtered.map((product) => product.from);
     const uniqueStores = Array.from(new Set(stores));
     set(() => ({ stores: uniqueStores }));
+  },
+  priceMin: null,
+  priceMax: null,
+  selectedCSI: null,
+  sortBy: "price_asc",
+  setPriceMin: (v) => set({ priceMin: v }),
+  setPriceMax: (v) => set({ priceMax: v }),
+  setSelectedCSI: (v) => set({ selectedCSI: v }),
+  setSortBy: (v) => set({ sortBy: v }),
+  clearFilters: () =>
+    set({ priceMin: null, priceMax: null, selectedCSI: null, sortBy: "price_asc" }),
+  filteredProducts: () => {
+    const { products, selectedBrand, selectedStore, priceMin, priceMax, selectedCSI, sortBy } = get();
+
+    let result = products.filter((p) => {
+      if (selectedBrand !== ALL && capitalize(p.brand) !== selectedBrand) return false;
+      if (selectedStore !== ALL && p.from !== selectedStore) return false;
+      if (priceMin !== null && (p.price ?? 0) < priceMin) return false;
+      if (priceMax !== null && (p.price ?? 0) > priceMax) return false;
+      if (selectedCSI !== null && (p.installment ?? 0) < selectedCSI) return false;
+      return true;
+    });
+
+    result = [...result].sort((a, b) => {
+      if (sortBy === "price_asc") return (a.price ?? Infinity) - (b.price ?? Infinity);
+      if (sortBy === "price_desc") return (b.price ?? 0) - (a.price ?? 0);
+      if (sortBy === "installments_desc") return (b.installment ?? 0) - (a.installment ?? 0);
+      if (sortBy === "best_installment") {
+        const aVal = (a.installment ?? 0) > 0 ? (a.price ?? 0) / a.installment! : Infinity;
+        const bVal = (b.installment ?? 0) > 0 ? (b.price ?? 0) / b.installment! : Infinity;
+        return aVal - bVal;
+      }
+      return 0;
+    });
+
+    return result;
   },
 }));


### PR DESCRIPTION
## Summary

- Extends `useProductsStore` with `priceMin`, `priceMax`, `selectedCSI`, `sortBy` + `filteredProducts()` selector
- `FilterPanel` — responsive (horizontal desktop / Dialog bottom sheet mobile), active filter badge, clear button
- `PriceRangeFilter` — Desde/Hasta number inputs
- `CSIFilter` — 4 chips with `aria-pressed` (Cualquiera / 6 CSI / 12 CSI / 18+ CSI)
- `SortControl` — 4 sort options bound to store
- `ProductList` refactored to consume `filteredProducts()`
- Storybook stories for all 4 new components

## Test plan

- [ ] Run `npm test` — 120 tests passing (includes 16 new TDD filter tests)
- [ ] Filter by price range — results update in real time
- [ ] Filter by CSI — only products with enough installments appear
- [ ] Sort by each option — order changes correctly
- [ ] Mobile: filter panel opens as bottom sheet dialog
- [ ] Clear filters — resets all state

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)