### PR TITLE
fix(redis): lazyConnect to suppress build-time connection errors

### DIFF
--- a/src/platform/redis/index.ts
+++ b/src/platform/redis/index.ts
@@ -11,6 +11,7 @@ const redis = new Redis({
   host: process.env.REDIS_URL ?? "127.0.0.1",
   port: parseInt(process.env.REDIS_PORT ?? "6379", 10),
   password: process.env.REDIS_PASSWORD,
+  lazyConnect: true,
   maxRetriesPerRequest: 5,
   retryStrategy: (times) => {
     // Estrategia de reintento exponencial


### PR DESCRIPTION
## Summary
- Add `lazyConnect: true` to ioredis config in `src/platform/redis/index.ts`

ioredis conecta inmediatamente al importarse el módulo. Durante `next build`, Next.js genera páginas estáticas e importa el módulo, provocando errores de conexión en los logs del build (aunque no falla el build).

Con `lazyConnect: true`, ioredis solo conecta cuando se ejecuta el primer comando real — no en el import.

## Test plan
- [ ] Build logs en Vercel no deben mostrar `Redis connection error: getaddrinfo ENOTFOUND`
- [ ] Las rutas `/api/scrape` y `/api/health` siguen funcionando en runtime normalmente