### PR TITLE
fix(proxy): remove module-level throw for API_SECRET_KEY

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,12 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-if (
-  process.env.NODE_ENV === 'production' &&
-  !process.env.API_SECRET_KEY
-) {
-  throw new Error('FATAL: API_SECRET_KEY environment variable is required in production');
-}
-
 interface RateLimitBucket {
   tokens: number;
   lastRefill: number;


### PR DESCRIPTION
Closes #104

## Summary
Elimina el throw a nivel de módulo en `src/proxy.ts` que crasheaba el middleware en producción si `API_SECRET_KEY` no estaba configurada en Vercel.

La función `proxy()` ya tiene `if (process.env.API_SECRET_KEY)` — el throw era redundante y contradictorio.

## Test plan
- [ ] Middleware arranca sin errores en producción sin `API_SECRET_KEY`
- [ ] Si `API_SECRET_KEY` está seteada, sigue validando el header `x-api-key`
- [ ] Si no está seteada, deja pasar los requests (comportamiento dev)