### PR TITLE
feat(redis): migrar a Upstash REST client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
+        "@upstash/redis": "^1.37.0",
         "@vercel/analytics": "^1.3.2",
         "axios": "^1.7.7",
         "cheerio": "^1.0.0",
@@ -7031,6 +7032,15 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.37.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.37.0.tgz",
+      "integrity": "sha512-LqOJ3+XWPLSZ2rGSed5DYG3ixybxb8EhZu3yQqF7MdZX1wLBG/FRcI6xcUZXHy/SS7mmXWyadrud0HJHkOc+uw==",
+      "license": "MIT",
+      "dependencies": {
+        "uncrypto": "^0.1.3"
+      }
     },
     "node_modules/@vercel/analytics": {
       "version": "1.3.2",
@@ -16379,6 +16389,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/uncrypto": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
+      "license": "MIT"
     },
     "node_modules/undici": {
       "version": "6.19.8",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
+    "@upstash/redis": "^1.37.0",
     "@vercel/analytics": "^1.3.2",
     "axios": "^1.7.7",
     "cheerio": "^1.0.0",

--- a/src/platform/cache/index.ts
+++ b/src/platform/cache/index.ts
@@ -59,7 +59,7 @@ export async function getQueryCache(
 export async function setQueryCache(key: string, data: unknown): Promise<void> {
   try {
     const entry: CacheEntry<unknown> = { data, createdAt: Date.now() };
-    await redis.set(key, JSON.stringify(entry), "EX", TTL.QUERY);
+    await redis.set(key, JSON.stringify(entry), { ex: TTL.QUERY });
   } catch (error) {
     console.error("[cache] setQueryCache error:", error);
   }
@@ -77,7 +77,7 @@ export async function setStoreCacheNX(
   try {
     const pipeline = redis.pipeline();
     for (const { key, data } of entries) {
-      pipeline.set(key, JSON.stringify(data), "EX", TTL.STORE, "NX");
+      pipeline.set(key, JSON.stringify(data), { ex: TTL.STORE, nx: true });
     }
     await pipeline.exec();
   } catch (error) {

--- a/src/platform/redis/__tests__/redis.test.ts
+++ b/src/platform/redis/__tests__/redis.test.ts
@@ -1,8 +1,6 @@
-jest.mock('ioredis', () => {
-  return jest.fn().mockImplementation(() => ({
-    on: jest.fn(),
-  }));
-});
+jest.mock('@upstash/redis', () => ({
+  Redis: jest.fn().mockImplementation(() => ({})),
+}));
 
 function loadRedis(): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -31,33 +29,28 @@ describe('Redis fail-fast in production', () => {
     process.env = originalEnv;
   });
 
-  it('throws when NODE_ENV=production and REDIS_PASSWORD is not set', async () => {
+  it('throws when NODE_ENV=production and UPSTASH_REDIS_REST_TOKEN is not set', async () => {
     (process.env as MutableEnv).NODE_ENV = 'production';
-    delete (process.env as MutableEnv).REDIS_PASSWORD;
-    await expect(loadRedis()).rejects.toThrow(/REDIS_PASSWORD/);
+    delete (process.env as MutableEnv).UPSTASH_REDIS_REST_TOKEN;
+    await expect(loadRedis()).rejects.toThrow(/UPSTASH_REDIS_REST_TOKEN/);
   });
 
-  it('throws when NODE_ENV=production and REDIS_PASSWORD is empty string', async () => {
+  it('does NOT throw when NODE_ENV=production and UPSTASH_REDIS_REST_TOKEN is set', async () => {
     (process.env as MutableEnv).NODE_ENV = 'production';
-    (process.env as MutableEnv).REDIS_PASSWORD = '';
-    await expect(loadRedis()).rejects.toThrow(/REDIS_PASSWORD/);
-  });
-
-  it('does NOT throw when NODE_ENV=production and REDIS_PASSWORD is set', async () => {
-    (process.env as MutableEnv).NODE_ENV = 'production';
-    (process.env as MutableEnv).REDIS_PASSWORD = 's3cr3t';
+    (process.env as MutableEnv).UPSTASH_REDIS_REST_TOKEN = 's3cr3t';
+    (process.env as MutableEnv).UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
     await expect(loadRedis()).resolves.toBeUndefined();
   });
 
-  it('does NOT throw when NODE_ENV=development and REDIS_PASSWORD is not set', async () => {
+  it('does NOT throw when NODE_ENV=development and UPSTASH_REDIS_REST_TOKEN is not set', async () => {
     (process.env as MutableEnv).NODE_ENV = 'development';
-    delete (process.env as MutableEnv).REDIS_PASSWORD;
+    delete (process.env as MutableEnv).UPSTASH_REDIS_REST_TOKEN;
     await expect(loadRedis()).resolves.toBeUndefined();
   });
 
-  it('does NOT throw when NODE_ENV=test and REDIS_PASSWORD is not set', async () => {
+  it('does NOT throw when NODE_ENV=test and UPSTASH_REDIS_REST_TOKEN is not set', async () => {
     (process.env as MutableEnv).NODE_ENV = 'test';
-    delete (process.env as MutableEnv).REDIS_PASSWORD;
+    delete (process.env as MutableEnv).UPSTASH_REDIS_REST_TOKEN;
     await expect(loadRedis()).resolves.toBeUndefined();
   });
 });

--- a/src/platform/redis/index.ts
+++ b/src/platform/redis/index.ts
@@ -7,23 +7,21 @@ if (
   throw new Error('FATAL: REDIS_PASSWORD environment variable is required in production');
 }
 
+const isUpstash = (process.env.REDIS_URL ?? "").includes("upstash.io");
+
 const redis = new Redis({
   host: process.env.REDIS_URL ?? "127.0.0.1",
   port: parseInt(process.env.REDIS_PORT ?? "6379", 10),
   password: process.env.REDIS_PASSWORD,
+  tls: isUpstash ? {} : undefined,
   lazyConnect: true,
   maxRetriesPerRequest: 5,
   retryStrategy: (times) => {
-    // Estrategia de reintento exponencial
     const delay = Math.min(times * 50, 2000);
     return delay;
   },
   reconnectOnError: (err) => {
-    const targetError = "READONLY";
-    if (err.message.includes(targetError)) {
-      // Solo reconectar en errores específicos
-      return true;
-    }
+    if (err.message.includes("READONLY")) return true;
     return false;
   },
 });

--- a/src/platform/redis/index.ts
+++ b/src/platform/redis/index.ts
@@ -1,33 +1,15 @@
-import Redis from "ioredis";
+import { Redis } from "@upstash/redis";
 
 if (
   process.env.NODE_ENV === 'production' &&
-  (process.env.REDIS_PASSWORD === undefined || process.env.REDIS_PASSWORD === '')
+  !process.env.UPSTASH_REDIS_REST_TOKEN
 ) {
-  throw new Error('FATAL: REDIS_PASSWORD environment variable is required in production');
+  throw new Error('FATAL: UPSTASH_REDIS_REST_TOKEN environment variable is required in production');
 }
 
-const isUpstash = (process.env.REDIS_URL ?? "").includes("upstash.io");
-
 const redis = new Redis({
-  host: process.env.REDIS_URL ?? "127.0.0.1",
-  port: parseInt(process.env.REDIS_PORT ?? "6379", 10),
-  password: process.env.REDIS_PASSWORD,
-  tls: isUpstash ? {} : undefined,
-  lazyConnect: true,
-  maxRetriesPerRequest: 5,
-  retryStrategy: (times) => {
-    const delay = Math.min(times * 50, 2000);
-    return delay;
-  },
-  reconnectOnError: (err) => {
-    if (err.message.includes("READONLY")) return true;
-    return false;
-  },
-});
-
-redis.on("error", (err) => {
-  console.error("Redis connection error:", err);
+  url: process.env.UPSTASH_REDIS_REST_URL ?? "",
+  token: process.env.UPSTASH_REDIS_REST_TOKEN ?? "",
 });
 
 export default redis;


### PR DESCRIPTION
## Summary
- Reemplaza ioredis por `@upstash/redis` REST client
- TLS nativo vía HTTP, ideal para serverless Vercel
- Env vars: `UPSTASH_REDIS_REST_URL` + `UPSTASH_REDIS_REST_TOKEN`
- Guard fail-fast actualizado para la nueva var en producción

## Test plan
- [x] 153 tests Jest verdes
- [ ] Configurar `UPSTASH_REDIS_REST_URL` y `UPSTASH_REDIS_REST_TOKEN` en Vercel env vars
- [ ] Redeploy y verificar logs sin errores Redis