### PR TITLE
fix(cache): tipado get<string> para @upstash/redis

### DIFF
--- a/src/platform/cache/index.ts
+++ b/src/platform/cache/index.ts
@@ -43,7 +43,7 @@ export async function getQueryCache(
   key: string,
 ): Promise<{ data: unknown; stale: boolean } | null> {
   try {
-    const raw = await redis.get(key);
+    const raw = await redis.get<string>(key);
     if (!raw) return null;
     const entry = JSON.parse(raw) as CacheEntry<unknown>;
     return { data: entry.data, stale: isSwr(entry.createdAt) };
@@ -91,7 +91,7 @@ export async function setStoreCacheNX(
  */
 export async function getCachedData(key: string): Promise<unknown> {
   try {
-    const raw = await redis.get(key);
+    const raw = await redis.get<string>(key);
     return raw ? JSON.parse(raw) : null;
   } catch {
     return null;


### PR DESCRIPTION
Fix TS build error: Argument of type '{}' is not assignable to parameter of type 'string' en cache/index.ts:48.