### PR TITLE
fix(scrapers): resolve 403 on Fravega and MercadoLibre in production

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "ioredis": "^5.10.1",
         "lucide-react": "^0.441.0",
         "next": "16.2.3",
         "next-themes": "^0.4.6",
@@ -1865,12 +1864,6 @@
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
-    },
-    "node_modules/@ioredis/commands": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
-      "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
-      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -8678,6 +8671,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8852,15 +8846,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/denque": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-2.1.0.tgz",
-      "integrity": "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/dequal": {
@@ -10816,30 +10801,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/ioredis": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
-      "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
-      "license": "MIT",
-      "dependencies": {
-        "@ioredis/commands": "1.5.1",
-        "cluster-key-slot": "^1.1.0",
-        "debug": "^4.3.4",
-        "denque": "^2.1.0",
-        "lodash.defaults": "^4.2.0",
-        "lodash.isarguments": "^3.1.0",
-        "redis-errors": "^1.2.0",
-        "redis-parser": "^3.0.0",
-        "standard-as-callback": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=12.22.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/ioredis"
-      }
-    },
     "node_modules/is-arguments": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
@@ -12654,18 +12615,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.defaults": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isarguments": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-      "integrity": "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==",
-      "license": "MIT"
-    },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -12926,6 +12875,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -14738,27 +14688,6 @@
         "@redis/time-series": "1.1.0"
       }
     },
-    "node_modules/redis-errors": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/redis-errors/-/redis-errors-1.2.0.tgz",
-      "integrity": "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/redis-parser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redis-parser/-/redis-parser-3.0.0.tgz",
-      "integrity": "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==",
-      "license": "MIT",
-      "dependencies": {
-        "redis-errors": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -15369,12 +15298,6 @@
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/standard-as-callback": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz",
-      "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
     "node_modules/standardwebhooks": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "ioredis": "^5.10.1",
     "lucide-react": "^0.441.0",
     "next": "16.2.3",
     "next-themes": "^0.4.6",

--- a/src/scrapers/fravega/index.ts
+++ b/src/scrapers/fravega/index.ts
@@ -43,8 +43,15 @@ function extraerMarcasDesdeNextData(
   return marcasPorId;
 }
 
+function buildFravegaUrl(query: string): string {
+  const target = `https://www.fravega.com/l/?keyword=${encodeURIComponent(query)}`;
+  const apiKey = process.env.SCRAPER_API_KEY;
+  if (!apiKey) return target;
+  return `https://api.scraperapi.com?api_key=${apiKey}&url=${encodeURIComponent(target)}`;
+}
+
 export async function scrapeFravega(query: string): Promise<Product[]> {
-  const url = `https://www.fravega.com/l/?keyword=${encodeURIComponent(query)}`;
+  const url = buildFravegaUrl(query);
   try {
     const { data } = await httpClient.get<string>(url, {
       headers: {

--- a/src/scrapers/mercadolibre/index.ts
+++ b/src/scrapers/mercadolibre/index.ts
@@ -1,113 +1,44 @@
-import { load } from "cheerio";
 import { capitalize } from "@/lib/capitalize";
 import { Product } from "@/types/product";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { httpClient } from "@/platform/http";
 
-interface JsonLdOffer {
-  "@type": string;
-  name?: string;
-  brand?: { "@type": string; name?: string } | string;
-  price?: number;
-  url?: string;
-  image?: string | string[];
+interface MeliAttribute {
+  id: string;
+  value_name?: string;
 }
 
-interface JsonLdDocument {
-  "@graph"?: JsonLdOffer[];
-  itemListElement?: { item?: JsonLdOffer }[];
+interface MeliResult {
+  title: string;
+  price: number;
+  thumbnail: string;
+  permalink: string;
+  attributes: MeliAttribute[];
 }
 
-/**
- * Extrae un mapa title→brand desde los bloques JSON-LD embebidos en el HTML de ML.
- * ML incluye schema.org/ItemList o schema.org/Product con el campo brand.
- */
-function extraerMarcasDesdeJsonLd(html: string): Map<string, string> {
-  const marcasPorTitulo = new Map<string, string>();
-  try {
-    const $ = load(html);
-    $('script[type="application/ld+json"]').each((_, el) => {
-      const raw = $(el).html();
-      if (!raw) return;
-      const json = JSON.parse(raw) as JsonLdDocument | JsonLdOffer;
-      let items: JsonLdOffer[];
-      if ("@graph" in json && Array.isArray(json["@graph"])) {
-        items = json["@graph"];
-      } else if ("itemListElement" in json && Array.isArray(json.itemListElement)) {
-        items = (json.itemListElement ?? [])
-          .map((e) => e.item)
-          .filter(Boolean) as JsonLdOffer[];
-      } else {
-        items = [json as JsonLdOffer];
-      }
-      for (const item of items) {
-        if (!item.name) continue;
-        const brand =
-          typeof item.brand === "string"
-            ? item.brand
-            : item.brand?.name ?? null;
-        if (brand) marcasPorTitulo.set(item.name.trim(), brand);
-      }
-    });
-  } catch {
-    // JSON-LD malformado — continuamos sin marcas
-  }
-  return marcasPorTitulo;
+interface MeliSearchResponse {
+  results: MeliResult[];
 }
 
 export async function scrapeMercadoLibre(query: string): Promise<Product[]> {
-  const formattedQuery = query.replaceAll(/\s+/g, "-");
-  const url = `https://listado.mercadolibre.com.ar/${encodeURIComponent(formattedQuery)}`;
+  const url = `https://api.mercadolibre.com/sites/MLA/search?q=${encodeURIComponent(query)}&limit=50`;
   try {
-    const { data } = await httpClient.get<string>(url, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-        "Accept-Language": "es-AR,es;q=0.9",
-      },
+    const { data } = await httpClient.get<MeliSearchResponse>(url);
+    return data.results.map((item) => {
+      const brandAttr = item.attributes.find((a) => a.id === "BRAND");
+      const brand = capitalize(brandAttr?.value_name ?? "Unknown");
+      const image = item.thumbnail.replace(/-I\.jpg$/, "-O.jpg");
+      return {
+        name: item.title,
+        price: item.price,
+        from: StoreNamesEnum.MERCADOLIBRE,
+        image,
+        url: item.permalink,
+        brand,
+      };
     });
-    const $ = load(data);
-    const marcasPorTitulo = extraerMarcasDesdeJsonLd(data);
-
-    const products: Product[] = $(".poly-card")
-      .map((_, item) => {
-        const anchor = $(item).find("a.poly-component__title");
-        const name = anchor.text().trim();
-        const productUrl = anchor.attr("href") ?? "";
-        const priceText = $(item)
-          .find(".andes-money-amount__fraction")
-          .first()
-          .text()
-          .trim()
-          .replaceAll(".", "");
-        const imageUrl =
-          $(item).find("img.poly-component__picture").attr("src") ??
-          $(item).find("img").attr("data-src") ??
-          "https://placehold.co/300x200";
-
-        // Intentar brand desde JSON-LD, luego desde el elemento de marca del card
-        const brandRaw =
-          marcasPorTitulo.get(name) ||
-          $(item).find(".poly-component__brand").text().trim() ||
-          "Unknown";
-
-        if (!name) return null;
-        return {
-          name,
-          price: Number(priceText),
-          from: StoreNamesEnum.MERCADOLIBRE,
-          image: imageUrl,
-          url: productUrl,
-          brand: capitalize(brandRaw),
-        };
-      })
-      .get()
-      .filter((p) => p !== null) as Product[];
-
-    return products;
   } catch (error) {
     console.error("Error fetching products from MercadoLibre:", error);
     return [];
   }
 }
-


### PR DESCRIPTION
## Summary

- **Fravega**: requests ahora pasan por ScraperAPI cuando `SCRAPER_API_KEY` está definida. Fallback al URL directo si no hay key (útil para tests).
- **MercadoLibre**: reemplaza HTML scraping por la API oficial (`api.mercadolibre.com/sites/MLA/search`). Sin bot detection, datos más confiables.
- **ioredis**: removido como dependencia muerta (todo el código Redis migró a `@upstash/redis`).

## Root cause

Fravega y MercadoLibre devolvían **HTTP 403** para requests provenientes de las IPs de datacenter de Vercel. Detectado via Vercel runtime logs.

## Test plan

- [x] 153 tests pasan (`npm test`)
- [x] `SCRAPER_API_KEY` agregada a Vercel production environment
- [x] Validado en producción: logs sin errores 403 post-deploy