### PR TITLE
feat(ui): align components to Quién Da Menos design system

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,7 +4,9 @@
 
 @layer base {
   body {
-    font-family: var(--font-geist-sans), sans-serif;
+    --font-sans:    var(--font-inter), -apple-system, BlinkMacSystemFont, sans-serif;
+    --font-display: var(--font-geist-sans), -apple-system, BlinkMacSystemFont, sans-serif;
+    font-family: var(--font-sans), sans-serif;
   }
 
   :root {
@@ -17,56 +19,99 @@
     --popover-foreground: 240 26% 5%;
     --primary: 142 72% 29%;            /* #15803d — WCAG AA 4.6:1 */
     --primary-foreground: 0 0% 100%;   /* #ffffff — WCAG AA */
-    --secondary: 240 5% 96%;          /* #f4f4f5 */
+    --secondary: 240 5% 96%;           /* #f4f4f5 */
     --secondary-foreground: 255 7% 11%; /* #1a191d */
-    --muted: 240 5% 96%;              /* #f4f4f5 */
-    --muted-foreground: 240 0% 44%;   /* #707070 — WCAG AA 4.7:1 */
+    --muted: 240 5% 96%;               /* #f4f4f5 */
+    --muted-foreground: 0 0% 39%;      /* #646464 — WCAG AA 5.7:1 */
     --accent: 240 5% 96%;
     --accent-foreground: 255 7% 11%;
-    --destructive: 0 74% 42%;         /* #b91c1c — WCAG AA 5.2:1 */
+    --destructive: 0 74% 42%;          /* #b91c1c — WCAG AA 5.2:1 */
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 55%;               /* #8c8c8c — WCAG AA 5.9:1 */
-    --input: 240 2% 90%;              /* #e5e5e6 */
-    --ring: 142 72% 29%;              /* #15803d */
+    --border: 240 1% 85%;              /* #d7d7db — soft hairline */
+    --input: 240 2% 90%;               /* #e5e5e6 */
+    --ring: 142 72% 29%;               /* #15803d */
     --radius: 0.5rem;
 
-    /* Figma extra tokens */
-    --price-green: 143 64% 24%;       /* #166534 — WCAG AA 7.0:1 */
-    --orange-500: 17 88% 40%;         /* #c2410c — WCAG AA */
-    --green-50: 130 67% 97%;          /* #f0fcf2 */
-    --surface: 240 11% 98%;           /* #fafafb */
-    --amber-300: 45 99% 69%;          /* #fed661 */
-    --amber-900: 30 100% 15%;         /* #4d2600 */
+    /* Figma extra tokens (HSL for Tailwind) */
+    --price-green: 143 64% 24%;        /* #166534 — WCAG AA 7.0:1 */
+    --orange-500: 17 88% 40%;          /* #c2410c */
+    --green-50: 130 67% 97%;           /* #f0fcf2 */
+    --surface: 240 11% 98%;            /* #fafafb */
+    --amber-300: 45 99% 69%;           /* #fed661 */
+    --amber-900: 30 100% 15%;          /* #4d2600 */
+
+    /* Design-system supplement (direct values for non-Tailwind usage) */
+    --shadow-header: 0 1px 4px 0 rgba(0, 0, 0, 0.05);
+    --shadow-card:   0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    --shadow-pop:    0 8px 24px -6px rgba(0, 0, 0, 0.12), 0 2px 6px -2px rgba(0, 0, 0, 0.08);
+
+    --radius-sm:   4px;
+    --radius-md:   6px;
+    --radius-lg:   8px;
+    --radius-xl:   12px;
+    --radius-2xl:  16px;
+    --radius-full: 9999px;
+
+    --price:            hsl(var(--price-green));
+    --price-down:       hsl(var(--price-green));
+    --price-down-bg:    hsl(var(--green-50));
+    --price-up:         hsl(var(--destructive));
+    --price-up-bg:      rgba(0, 0, 0, 0.08);
+    --installment:      hsl(var(--orange-500));
+    --info-bg:          hsl(var(--amber-300));
+    --info-foreground:  hsl(var(--amber-900));
+    --error-bg:         hsl(var(--destructive) / 0.06);
   }
 
   .dark {
     /* === Figma Design Tokens — Dark Mode === */
-    --background: 144 20% 5%;         /* #0a0f0c */
-    --foreground: 0 0% 98%;           /* #fafafa */
-    --card: 140 21% 8%;               /* #111a14 */
-    --card-foreground: 0 0% 98%;      /* #fafafa */
+    --background: 144 20% 5%;          /* #0a0f0c */
+    --foreground: 0 0% 98%;            /* #fafafa */
+    --card: 140 21% 8%;                /* #111a14 */
+    --card-foreground: 0 0% 98%;       /* #fafafa */
     --popover: 140 21% 8%;
     --popover-foreground: 0 0% 98%;
-    --primary: 142 71% 45%;           /* #22c55e */
+    --primary: 142 71% 45%;            /* #22c55e */
     --primary-foreground: 145 80% 10%; /* #052e16 */
-    --secondary: 145 17% 14%;         /* #1d2922 */
-    --secondary-foreground: 0 0% 98%; /* #fafafa */
-    --muted: 145 17% 14%;             /* #1d2922 */
-    --muted-foreground: 135 8% 63%;   /* #98a89c */
+    --secondary: 145 17% 14%;          /* #1d2922 */
+    --secondary-foreground: 0 0% 98%;  /* #fafafa */
+    --muted: 145 17% 14%;              /* #1d2922 */
+    --muted-foreground: 135 8% 63%;    /* #98a89c */
     --accent: 145 17% 14%;
     --accent-foreground: 0 0% 98%;
-    --destructive: 0 84% 60%;         /* #ef4444 */
+    --destructive: 0 84% 60%;          /* #ef4444 */
     --destructive-foreground: 0 86% 97%;
-    --border: 143 27% 33%;            /* #3d6b4f — WCAG AA */
-    --input: 134 18% 14%;             /* #1e2b21 */
-    --ring: 142 71% 45%;              /* #22c55e */
+    --border: 146 28% 22%;             /* #2c4537 — dark hairline */
+    --input: 134 18% 14%;              /* #1e2b21 */
+    --ring: 142 71% 45%;               /* #22c55e */
 
-    /* Figma extra tokens */
-    --price-green: 142 71% 45%;       /* #22c55e */
-    --orange-500: 17 88% 40%;         /* #c2410c — WCAG AA */
-    --green-50: 145 80% 10%;          /* #052e16 */
-    --surface: 140 21% 8%;            /* #111a14 */
-    --amber-300: 45 99% 69%;          /* #fed661 */
-    --amber-900: 43 96% 56%;          /* #fbbf24 — WCAG AA on dark bg */
+    /* Figma extra tokens (HSL for Tailwind) */
+    --price-green: 142 71% 45%;        /* #22c55e */
+    --orange-500: 17 88% 40%;          /* #c2410c */
+    --green-50: 145 80% 10%;           /* #052e16 */
+    --surface: 140 21% 8%;             /* #111a14 */
+    --amber-300: 45 99% 69%;           /* #fed661 — stays light (banner bg) */
+    /* --amber-900 intentionally NOT overridden: banner text stays dark #4d2600 */
+
+    /* Design-system supplement overrides */
+    --price-up-bg: rgba(255, 255, 255, 0.10);
+    --error-bg:    rgba(185, 28, 28, 0.12);
   }
+}
+
+@keyframes se-shimmer {
+  0%   { background-position: 100% 0; }
+  100% { background-position: 0 0; }
+}
+
+.se-shimmer,
+.se-shimmer-line {
+  background: linear-gradient(
+    90deg,
+    hsl(var(--muted)) 25%,
+    hsl(var(--surface)) 37%,
+    hsl(var(--muted)) 63%
+  );
+  background-size: 400% 100%;
+  animation: se-shimmer 1.4s ease-in-out infinite;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,23 +1,23 @@
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+import { Geist, Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/ThemeProvider";
 
-const geistSans = localFont({
-  src: "./fonts/GeistVF.woff",
+const geistSans = Geist({
+  subsets: ["latin"],
   variable: "--font-geist-sans",
-  weight: "100 900",
 });
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
+const inter = Inter({
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  variable: "--font-inter",
+  display: "swap",
 });
 
 export const metadata: Metadata = {
-  title: "Scraping de Tiendas de Electrónica",
+  title: "Quién Da Menos — Comparador de precios",
   description:
-    "Comparador de precios y especificaciones de productos electrónicos",
+    "Buscá una vez y comparamos precios en Frávega, Cetrogar, Musimundo, Megatone y más al mismo tiempo.",
 };
 
 export default function RootLayout({
@@ -27,9 +27,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es" suppressHydrationWarning>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} ${inter.variable} antialiased`}>
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/Disclaimer/Disclaimer.tsx
+++ b/src/components/Disclaimer/Disclaimer.tsx
@@ -7,11 +7,13 @@ export default function Disclaimer() {
   if (!visible) return null;
 
   return (
-    <div className="bg-amber-300/10 border border-amber-300/20 rounded-lg p-4 flex gap-3 items-start w-full">
-      <div className="text-amber-900 flex items-center justify-center shrink-0 size-5">
-        <span className="font-bold text-base leading-none select-none">ℹ</span>
+    <div className="flex w-full items-start gap-3 rounded-lg bg-amber-300 p-4">
+      <div className="flex size-5 shrink-0 items-center justify-center text-amber-900">
+        <span className="select-none text-base font-bold italic leading-none">
+          i
+        </span>
       </div>
-      <div className="flex flex-col gap-1 flex-1 min-w-0">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
         <p className="text-base font-bold text-amber-900">¿Cómo funciona?</p>
         <p className="text-sm font-normal leading-5 text-amber-900">
           Los precios se actualizan en cada búsqueda y pueden variar al momento
@@ -19,11 +21,11 @@ export default function Disclaimer() {
         </p>
       </div>
       <button
-        className="min-w-[44px] min-h-[44px] flex items-center justify-center text-amber-900 shrink-0 hover:bg-amber-300/20 rounded transition-colors"
+        className="flex min-h-[44px] min-w-[44px] shrink-0 items-center justify-center rounded text-amber-900 transition-colors hover:bg-amber-300/20"
         onClick={() => setVisible(false)}
         aria-label="Cerrar aviso"
       >
-        <span className="text-base leading-none select-none">×</span>
+        <span className="select-none text-base leading-none">×</span>
       </button>
     </div>
   );

--- a/src/components/EmptyState/EmptyState.tsx
+++ b/src/components/EmptyState/EmptyState.tsx
@@ -1,15 +1,21 @@
-export function EmptyState() {
+import { Search } from "lucide-react";
+
+interface EmptyStateProps {
+  title?: string;
+  children?: React.ReactNode;
+}
+
+export function EmptyState({
+  title = "Sin resultados",
+  children,
+}: EmptyStateProps) {
   return (
-    <div className="bg-surface border border-border rounded-xl flex flex-col gap-4 items-center justify-center h-[300px] w-full max-w-[520px] mx-auto">
-      <div className="bg-muted rounded-[32px] size-16 overflow-hidden relative shrink-0">
-        <div className="bg-muted-foreground/40 rounded-[14px] size-7 absolute left-[18px] top-4" />
-      </div>
-      <div className="flex flex-col gap-2 items-center text-center px-6">
-        <p className="text-lg font-medium text-foreground">Sin resultados</p>
-        <p className="text-sm text-muted-foreground">
-          Probá con otro término de búsqueda o revisá los filtros.
-        </p>
-      </div>
+    <div className="flex flex-col items-center gap-3 px-4 py-12 text-center">
+      <Search className="h-10 w-10 text-muted-foreground" />
+      <p className="text-lg font-semibold text-foreground">{title}</p>
+      <p className="text-sm text-muted-foreground">
+        {children ?? "Probá con otro término de búsqueda o revisá los filtros."}
+      </p>
     </div>
   );
 }

--- a/src/components/ErrorAlert/ErrorAlert.tsx
+++ b/src/components/ErrorAlert/ErrorAlert.tsx
@@ -7,13 +7,16 @@ export function ErrorAlert() {
   return (
     <div
       role="alert"
-      className="rounded-lg border border-destructive/30 bg-destructive/10 px-4 py-3 flex items-start gap-3"
+      className="flex items-start gap-3 rounded-lg border border-destructive/20 px-4 py-3"
+      style={{ background: "var(--error-bg)" }}
     >
-      <div className="size-5 rounded-full bg-destructive shrink-0 mt-0.5 flex items-center justify-center">
-        <div className="w-0.5 h-2.5 bg-white rounded-full" />
+      <div className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-full bg-destructive">
+        <div className="h-2.5 w-0.5 rounded-full bg-white" />
       </div>
       <div className="flex flex-col gap-0.5">
-        <p className="text-sm font-semibold text-destructive">Error al cargar resultados</p>
+        <p className="text-sm font-semibold text-destructive">
+          Error al cargar resultados
+        </p>
         <p className="text-xs text-destructive/80">{error}</p>
       </div>
     </div>

--- a/src/components/FiltersBar/FiltersBar.tsx
+++ b/src/components/FiltersBar/FiltersBar.tsx
@@ -19,10 +19,6 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-function Divider() {
-  return <div className="w-px h-7 bg-border shrink-0" />;
-}
-
 export function FiltersBar() {
   const [brandOpen, setBrandOpen] = React.useState(false);
 
@@ -40,8 +36,8 @@ export function FiltersBar() {
   const csiOptions = useMemo(() => getAvailableCSI(products), [products]);
 
   return (
-    <div className="h-[46px] bg-muted border border-border rounded-xl flex items-center overflow-hidden flex-1 min-w-0">
-      {/* Marca */}
+    <div className="flex flex-wrap items-center gap-2">
+      {/* Brand pill */}
       <Popover open={brandOpen} onOpenChange={setBrandOpen}>
         <PopoverTrigger asChild>
           <button
@@ -49,18 +45,22 @@ export function FiltersBar() {
             aria-haspopup="listbox"
             aria-expanded={brandOpen}
             aria-label="Seleccionar marca"
-            className="flex items-center gap-1.5 px-3 h-full hover:bg-accent transition-colors shrink-0"
+            className="flex h-[40px] shrink-0 items-center gap-1.5 rounded-lg border border-border bg-background px-3 text-sm transition-colors hover:bg-muted"
           >
-            <span className={cn(
-              "text-sm leading-none whitespace-nowrap",
-              selectedBrand === ALL ? "text-muted-foreground" : "text-foreground font-medium"
-            )}>
+            <span
+              className={cn(
+                "whitespace-nowrap leading-none",
+                selectedBrand === ALL
+                  ? "text-muted-foreground"
+                  : "font-medium text-foreground",
+              )}
+            >
               {selectedBrand === ALL ? "Marca" : selectedBrand}
             </span>
-            <ChevronDownIcon className="h-3 w-3 shrink-0 text-primary" />
+            <ChevronDownIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
           </button>
         </PopoverTrigger>
-        <PopoverContent className="p-0 w-[200px]" align="start">
+        <PopoverContent className="w-[200px] p-0" align="start">
           <Command>
             <CommandInput placeholder="Buscar marca..." className="h-9" />
             <CommandList>
@@ -71,13 +71,23 @@ export function FiltersBar() {
                     key={brand}
                     value={brand}
                     onSelect={(value) => {
-                      const matched = brands.find((b) => b.toLowerCase() === value.toLowerCase()) ?? ALL;
-                      setSelectedBrand(selectedBrand === matched ? ALL : matched);
+                      const matched =
+                        brands.find(
+                          (b) => b.toLowerCase() === value.toLowerCase(),
+                        ) ?? ALL;
+                      setSelectedBrand(
+                        selectedBrand === matched ? ALL : matched,
+                      );
                       setBrandOpen(false);
                     }}
                   >
                     {brand}
-                    <CheckIcon className={cn("ml-auto h-4 w-4", selectedBrand === brand ? "opacity-100" : "opacity-0")} />
+                    <CheckIcon
+                      className={cn(
+                        "ml-auto h-4 w-4",
+                        selectedBrand === brand ? "opacity-100" : "opacity-0",
+                      )}
+                    />
                   </CommandItem>
                 ))}
               </CommandGroup>
@@ -86,67 +96,57 @@ export function FiltersBar() {
         </PopoverContent>
       </Popover>
 
-      <Divider />
-
-      {/* Precio — Desde */}
-      <label className="flex flex-col gap-0.5 px-3 py-1.5 shrink-0">
-        <span className="text-[10px] text-muted-foreground leading-none whitespace-nowrap">Desde</span>
+      {/* Price pill */}
+      <div className="flex h-[40px] shrink-0 items-center gap-2 rounded-lg border border-border bg-background px-3 text-sm">
+        <span className="shrink-0 text-muted-foreground">$</span>
         <input
           type="number"
           min={0}
           value={priceMin ?? ""}
-          onChange={(e) => setPriceMin(e.target.value ? Number(e.target.value) : null)}
-          placeholder="$ 0"
-          className="text-sm font-medium text-foreground leading-none bg-transparent outline-none w-[60px] placeholder:text-muted-foreground [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          onChange={(e) =>
+            setPriceMin(e.target.value ? Number(e.target.value) : null)
+          }
+          placeholder="desde"
+          className="w-[52px] bg-transparent text-sm font-medium leading-none text-foreground outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           aria-label="Precio mínimo"
         />
-      </label>
-
-      <Divider />
-
-      {/* Precio — Hasta */}
-      <label className="flex flex-col gap-0.5 px-3 py-1.5 shrink-0">
-        <span className="text-[10px] text-muted-foreground leading-none whitespace-nowrap">Hasta</span>
+        <span className="shrink-0 text-muted-foreground">–</span>
         <input
           type="number"
           min={0}
           value={priceMax ?? ""}
-          onChange={(e) => setPriceMax(e.target.value ? Number(e.target.value) : null)}
-          placeholder="$ ∞"
-          className="text-sm font-medium text-foreground leading-none bg-transparent outline-none w-[60px] placeholder:text-muted-foreground [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          onChange={(e) =>
+            setPriceMax(e.target.value ? Number(e.target.value) : null)
+          }
+          placeholder="hasta"
+          className="w-[52px] bg-transparent text-sm font-medium leading-none text-foreground outline-none [appearance:textfield] placeholder:text-muted-foreground [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           aria-label="Precio máximo"
         />
-      </label>
+      </div>
 
+      {/* Cuotas segmented control */}
       {csiOptions.length > 1 && (
-        <>
-          <Divider />
-          <div
-            className="flex flex-col gap-0.5 px-3 py-1.5 shrink-0"
-            role="group"
-            aria-label="Cuotas sin interés"
-          >
-            <span className="text-[10px] text-muted-foreground leading-none whitespace-nowrap">Cuotas</span>
-            <div className="flex items-center gap-2.5">
-              {csiOptions.map(({ label, value }) => {
-                const active = selectedCSI === value;
-                return (
-                  <button
-                    key={label}
-                    onClick={() => setSelectedCSI(value)}
-                    className={cn(
-                      "text-sm leading-none transition-colors whitespace-nowrap",
-                      active ? "text-primary font-medium" : "text-muted-foreground hover:text-foreground"
-                    )}
-                    aria-pressed={active}
-                  >
-                    {label}
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-        </>
+        <fieldset className="m-0 flex shrink-0 items-center gap-0.5 rounded-full border-0 bg-secondary p-1">
+          <legend className="sr-only">Cuotas sin interés</legend>
+          {csiOptions.map(({ label, value }) => {
+            const active = selectedCSI === value;
+            return (
+              <button
+                key={label}
+                onClick={() => setSelectedCSI(value)}
+                aria-pressed={active}
+                className={cn(
+                  "h-8 whitespace-nowrap rounded-full px-3 text-xs font-medium transition-colors",
+                  active
+                    ? "bg-card text-foreground shadow-card"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </fieldset>
       )}
     </div>
   );

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -2,7 +2,7 @@ import Cafecito from "@/components/Cafecito";
 
 export function Footer() {
   return (
-    <footer className="w-full bg-green-50 dark:bg-card h-[64px] flex items-center justify-end px-6 overflow-hidden shrink-0">
+    <footer className="flex h-[64px] w-full shrink-0 items-center justify-end overflow-hidden bg-green-50 px-6">
       <Cafecito />
     </footer>
   );

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,32 +4,40 @@ import { ModeToggle } from "@/components/DarkMode";
 
 export function Header() {
   return (
-    <header className="w-full bg-background shadow-[0_1px_4px_0_rgba(0,0,0,0.05)] shrink-0">
+    <header className="w-full shrink-0 bg-card shadow-[0_1px_4px_0_rgba(0,0,0,0.05)]">
       {/* Mobile header */}
-      <div className="flex sm:hidden h-14 items-center justify-between px-4">
-        <div className="flex items-center justify-center size-[39.6px] shrink-0">
-          <div className="rotate-45">
-            <div className="size-7 overflow-hidden">
-              <Image src="/logo.png" alt="Logo" width={28} height={28} className="object-contain" />
-            </div>
+      <div className="flex h-14 items-center justify-between px-4 sm:hidden">
+        <div className="flex items-center gap-2">
+          <div className="flex size-7 shrink-0 items-center justify-center">
+            <Image
+              src="/logo.png"
+              alt="Logo"
+              width={28}
+              height={28}
+              className="rotate-[30deg] object-contain"
+            />
           </div>
+          <span className="text-[15px] font-semibold text-foreground">
+            Quién Da Menos
+          </span>
         </div>
-        <span className="text-base font-bold text-foreground">Scraping</span>
-        <div className="size-7 shrink-0" />
+        <ModeToggle />
       </div>
 
       {/* Desktop header */}
-      <div className="hidden sm:flex h-14 items-center justify-between px-6">
+      <div className="hidden h-14 items-center justify-between px-6 sm:flex">
         <div className="flex items-center gap-2.5">
-          <div className="flex items-center justify-center size-[56.57px] shrink-0">
-            <div className="rotate-45">
-              <div className="size-10 overflow-hidden">
-                <Image src="/logo.png" alt="Logo" width={40} height={40} className="object-contain" />
-              </div>
-            </div>
+          <div className="flex size-9 shrink-0 items-center justify-center">
+            <Image
+              src="/logo.png"
+              alt="Logo"
+              width={36}
+              height={36}
+              className="rotate-[30deg] object-contain"
+            />
           </div>
           <span className="text-xl font-semibold leading-7 text-foreground">
-            Scraping Electronica
+            Quién Da Menos
           </span>
         </div>
         <div className="flex items-center gap-2">

--- a/src/components/ProductList/ProductList.tsx
+++ b/src/components/ProductList/ProductList.tsx
@@ -21,15 +21,15 @@ function SkeletonCard() {
   return (
     <div
       data-testid="skeleton-card"
-      className="flex animate-pulse flex-col overflow-hidden rounded-xl border border-border bg-card"
+      className="flex flex-col overflow-hidden rounded-xl border border-border bg-card"
     >
-      <div className="h-[140px] w-full shrink-0 bg-muted" />
+      <div className="se-shimmer h-[140px] w-full shrink-0" />
       <div className="flex w-full flex-col gap-[10px] p-3">
-        <div className="h-[10px] w-[80px] rounded-sm bg-muted" />
-        <div className="h-[10px] w-full rounded-sm bg-muted" />
-        <div className="h-[10px] w-3/4 rounded-sm bg-muted" />
-        <div className="h-[24px] w-[60px] rounded-sm bg-muted" />
-        <div className="h-[18px] w-[100px] rounded-sm bg-muted" />
+        <div className="se-shimmer h-[10px] w-[80px] rounded-sm" />
+        <div className="se-shimmer h-[10px] w-full rounded-sm" />
+        <div className="se-shimmer h-[10px] w-3/4 rounded-sm" />
+        <div className="se-shimmer h-[24px] w-[60px] rounded-sm" />
+        <div className="se-shimmer h-[18px] w-[100px] rounded-sm" />
       </div>
     </div>
   );
@@ -115,7 +115,7 @@ export default function ProductList() {
               href={product.url}
               target="_blank"
               data-testid="product-card"
-              className="flex flex-col items-center overflow-hidden rounded-xl border border-border bg-card transition-colors hover:border-primary/40"
+              className="flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-all duration-150 hover:-translate-y-[3px] hover:border-transparent hover:shadow-pop"
             >
               <div className="relative h-[140px] w-full overflow-hidden bg-surface">
                 <Image
@@ -126,20 +126,21 @@ export default function ProductList() {
                   sizes="(min-width: 768px) 25vw, (min-width: 640px) 33vw, 50vw"
                   className="object-contain p-3"
                 />
-                <div className="absolute bottom-2 right-2 rounded-[4px] bg-card/90 px-2 py-[3px]">
-                  <span className="whitespace-nowrap text-xs font-medium text-secondary-foreground">
+                <div className="absolute left-[10px] top-[10px] rounded-full border border-border bg-card px-[9px] py-1">
+                  <span className="whitespace-nowrap text-[11px] font-semibold leading-none text-card-foreground">
                     {product.from}
                   </span>
                 </div>
               </div>
 
               <div className="flex w-full flex-col gap-[6px] p-3">
-                <h3 className="line-clamp-2 text-sm font-normal text-muted-foreground">
+                <h3 className="line-clamp-2 font-display text-sm font-normal text-muted-foreground">
                   {product.name}
                 </h3>
                 <p
                   data-testid="product-price"
-                  className="text-2xl font-bold text-price-green"
+                  className="font-display font-bold text-price-green"
+                  style={{ fontSize: "clamp(18px, 1.4vw + 14px, 24px)" }}
                 >
                   {product.price.toLocaleString("es-AR", {
                     style: "currency",
@@ -160,8 +161,9 @@ export default function ProductList() {
                     {trendMap["__global__"].delta}% vs ayer
                   </Badge>
                 )}
+                <div className="h-px bg-border" />
                 <div className="flex flex-wrap items-start gap-[6px]">
-                  <span className="text-xs font-medium uppercase text-muted-foreground">
+                  <span className="font-display text-xs font-semibold uppercase tracking-[0.02em] text-muted-foreground">
                     {product.brand}
                   </span>
                   {product.installment ? (
@@ -184,7 +186,7 @@ export default function ProductList() {
           <button
             onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
             disabled={currentPage === 1}
-            className="h-[36px] flex-1 rounded-md border border-border px-3 text-sm text-foreground disabled:opacity-40 sm:w-[120px] sm:flex-none"
+            className="h-[40px] flex-1 rounded-lg border border-border px-3 text-sm text-foreground disabled:opacity-40 sm:w-[120px] sm:flex-none"
           >
             ← <span className="hidden sm:inline">Anterior</span>
             <span className="sm:hidden">Ant.</span>
@@ -209,7 +211,7 @@ export default function ProductList() {
               item === "ellipsis" ? (
                 <span
                   key={`ellipsis-${arr[i - 1]}-${arr[i + 1]}`}
-                  className="flex size-[36px] select-none items-center justify-center text-xs text-muted-foreground"
+                  className="flex size-[40px] select-none items-center justify-center text-xs text-muted-foreground"
                 >
                   •••
                 </span>
@@ -219,8 +221,8 @@ export default function ProductList() {
                   onClick={() => setCurrentPage(item)}
                   className={
                     item === currentPage
-                      ? "size-[36px] rounded-md bg-primary text-sm font-medium text-primary-foreground"
-                      : "size-[36px] rounded-md border border-border text-sm text-foreground"
+                      ? "size-[40px] rounded-lg bg-primary text-sm font-medium text-primary-foreground"
+                      : "size-[40px] rounded-lg border border-border text-sm text-foreground"
                   }
                 >
                   {item}
@@ -231,7 +233,7 @@ export default function ProductList() {
           <button
             onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
             disabled={currentPage === totalPages}
-            className="h-[36px] flex-1 rounded-md border border-border px-3 text-sm text-foreground disabled:opacity-40 sm:w-[120px] sm:flex-none"
+            className="h-[40px] flex-1 rounded-lg border border-border px-3 text-sm text-foreground disabled:opacity-40 sm:w-[120px] sm:flex-none"
           >
             <span className="hidden sm:inline">Siguiente</span>
             <span className="sm:hidden">Sig.</span> →

--- a/src/components/ResultsHeader/ResultsHeader.tsx
+++ b/src/components/ResultsHeader/ResultsHeader.tsx
@@ -12,7 +12,7 @@ export function ResultsHeader() {
     <div className="flex items-center justify-between gap-4">
       <span
         data-testid="results-count"
-        className="text-xs font-medium text-foreground sm:text-sm"
+        className="font-display text-xs font-medium text-foreground sm:text-sm"
       >
         {count} resultado{count === 1 ? "" : "s"}
       </span>

--- a/src/components/StoreFilter/StoreFilter.tsx
+++ b/src/components/StoreFilter/StoreFilter.tsx
@@ -13,8 +13,10 @@ export function StoreFilter() {
   if (stores.length === 0) return null;
 
   return (
-    <div className="flex items-center gap-2 flex-wrap">
-      <span className="hidden sm:inline text-sm font-medium text-muted-foreground shrink-0">Tiendas:</span>
+    <div className="flex flex-wrap items-center gap-2">
+      <span className="hidden shrink-0 text-sm font-medium text-muted-foreground sm:inline">
+        Tiendas:
+      </span>
       {stores.map((store) => {
         const active = selectedStores.includes(store);
         return (
@@ -23,12 +25,30 @@ export function StoreFilter() {
             onClick={() => toggleStore(store)}
             aria-pressed={active}
             className={cn(
-              "px-3 py-1.5 rounded-full text-xs font-medium transition-colors",
+              "inline-flex items-center gap-[5px] rounded-full px-3 py-[7px] text-xs font-medium transition-colors",
               active
                 ? "bg-primary text-primary-foreground"
-                : "bg-muted text-secondary-foreground border border-border hover:border-primary"
+                : "bg-secondary text-secondary-foreground hover:brightness-[0.96]",
             )}
           >
+            {active && (
+              <svg
+                viewBox="0 0 13 13"
+                width="13"
+                height="13"
+                className="shrink-0"
+                aria-hidden="true"
+              >
+                <path
+                  d="M3 7.4 5.6 10 11 4"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  fill="none"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            )}
             {store}
           </button>
         );

--- a/src/components/StoresList/StoresList.tsx
+++ b/src/components/StoresList/StoresList.tsx
@@ -16,15 +16,15 @@ export function StoresList() {
   if (isLoading) return <Skeleton className="h-9 w-full" />;
 
   return (
-    <div className="bg-card border border-border rounded-[10px] px-4 py-[14px] flex flex-col gap-[6px] w-full">
-      <div className="flex gap-2 items-center">
-        <Store className="h-5 w-5 text-foreground shrink-0" />
+    <div className="flex w-full flex-col gap-[6px] rounded-lg bg-card px-4 py-[14px] shadow-[inset_0_0_0_1px_hsl(var(--border))]">
+      <div className="flex items-center gap-2">
+        <Store className="h-5 w-5 shrink-0 text-foreground" />
         <span className="text-base font-semibold text-foreground">
           Tiendas consultadas en:
         </span>
         <span className="text-lg">🇦🇷</span>
       </div>
-      <p className="text-sm text-muted-foreground leading-[1.5]">
+      <p className="text-sm leading-[1.5] text-muted-foreground">
         Resultados encontrados en {stores.length}{" "}
         {stores.length === 1 ? "tienda" : "tiendas"}: {stores.join(", ")}
       </p>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -67,14 +67,22 @@ const config: Config = {
       },
       keyframes: {
         bell: {
-          '0%, 100%': { transform: 'rotate(0deg)' },
-          '25%': { transform: 'rotate(30deg)' },
-          '75%': { transform: 'rotate(-30deg)' },
+          "0%, 100%": { transform: "rotate(0deg)" },
+          "25%": { transform: "rotate(30deg)" },
+          "75%": { transform: "rotate(-30deg)" },
         },
       },
       animation: {
-        bell: 'bell 1s ease-in-out infinite',
-      }
+        bell: "bell 1s ease-in-out infinite",
+      },
+      fontFamily: {
+        display: ["var(--font-display)", "system-ui", "sans-serif"],
+        sans: ["var(--font-sans)", "system-ui", "sans-serif"],
+      },
+      boxShadow: {
+        pop: "0 8px 24px -6px rgba(0,0,0,0.12), 0 2px 6px -2px rgba(0,0,0,0.08)",
+        card: "0 1px 2px 0 rgba(0,0,0,0.05)",
+      },
     },
   },
   plugins: [tailwindcssAnimate],


### PR DESCRIPTION
## Summary

- Switch Geist and Inter to `next/font/google` (replaces local WOFF files; matches DS font source exactly)
- Fix CSS variable resolution bug: `--font-sans`/`--font-display` moved to `body` so `next/font` vars resolve correctly (they're injected on `body`, not `:root`)
- Apply `font-display` (Geist) to product names, prices, and brand labels; Inter for all UI chrome
- StoreFilter chips: borderless unselected state, checkmark SVG when active, 34px height
- FiltersBar: discrete pill layout (brand pill + price pill + segmented Cuotas control)
- Pagination: 40px cells, `rounded-lg`
- StoresList: inset hairline `shadow-[inset_0_0_0_1px_hsl(var(--border))]` instead of `border`
- SkeletonCard: `se-shimmer` gradient animation instead of `animate-pulse`
- Header, Footer, Disclaimer, EmptyState, ErrorAlert: previous design system alignment pass

## Test plan

- [x] 164 Jest tests passing
- [x] ESLint clean
- [x] Production build successful
- [x] Verified via Playwright: `productName_h3 → Geist`, `productPrice → Geist`, `storeChip → Inter`, `searchInput → Inter`
- [ ] Manual visual QA in browser (dark mode + light mode)