### PR TITLE
chore: ignore .playwright-mcp directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ blob-report/
 
 # Claude Code — local personal settings (no commitear)
 .claude/settings.local.json
+.playwright-mcp/


### PR DESCRIPTION
Adds `.playwright-mcp/` to `.gitignore` to prevent Playwright MCP screenshot artifacts from appearing as uncommitted changes.