### PR TITLE
feat(ui): ProductDetail sheet with cross-store comparison and price history

### DIFF
--- a/e2e/product-detail.spec.ts
+++ b/e2e/product-detail.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { buildProducts } from "./fixtures/products";
+import { StoreNamesEnum } from "@/enums/stores.enum";
+import {
+  gotoAndWaitReady,
+  mockScrapeApi,
+  submitSearchAndWait,
+} from "./helpers/setup";
+import { getSelectors } from "./helpers/selectors";
+
+test.describe("ProductDetail Sheet", () => {
+  test.beforeEach(async ({ page }) => {
+    const products = buildProducts(3, { from: StoreNamesEnum.FRAVEGA });
+    await mockScrapeApi(page, products);
+
+    // Mock price history API to return empty (avoid network calls in tests)
+    await page.route("**/api/prices/history**", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([]),
+      });
+    });
+
+    await gotoAndWaitReady(page);
+    await submitSearchAndWait(page, "celular");
+  });
+
+  test("card click opens Sheet without URL change", async ({ page }) => {
+    const sel = getSelectors(page);
+    const initialUrl = page.url();
+
+    await expect(sel.productCards).toHaveCount(3);
+
+    // Click first product card
+    await sel.productCards.first().click();
+
+    // Sheet should be open (SheetContent renders in a portal with role="dialog")
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // URL should not have changed
+    expect(page.url()).toBe(initialUrl);
+  });
+
+  test('"Ir a tienda" button opens a new tab', async ({ page, context }) => {
+    const sel = getSelectors(page);
+
+    await sel.productCards.first().click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+
+    // "Ir a [store]" opens a new tab via window.open(_blank)
+    const [newPage] = await Promise.all([
+      context.waitForEvent("page"),
+      page.getByRole("button", { name: /Ir a/i }).first().click(),
+    ]);
+
+    await newPage.waitForLoadState("domcontentloaded");
+    expect(newPage.url()).toContain("example.com");
+  });
+
+  test("close button closes the Sheet", async ({ page }) => {
+    const sel = getSelectors(page);
+
+    await sel.productCards.first().click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // Click the close button (Cross2Icon button with sr-only "Close" text)
+    await page.getByRole("button", { name: /close/i }).click();
+
+    await expect(dialog).toBeHidden();
+  });
+});

--- a/src/components/CompareTable/CompareTable.tsx
+++ b/src/components/CompareTable/CompareTable.tsx
@@ -1,0 +1,88 @@
+import { Button } from "@/components/ui/button";
+import type { CompareOffer } from "@/features/price-search/match";
+
+interface CompareTableProps {
+  offers: CompareOffer[];
+  onGoToStore: (url: string) => void;
+}
+
+const fmtARS = (n: number) =>
+  n === Infinity
+    ? "—"
+    : n.toLocaleString("es-AR", { style: "currency", currency: "ARS" });
+
+export function CompareTable({ offers, onGoToStore }: CompareTableProps) {
+  const sorted = [...offers].sort((a, b) => a.price - b.price);
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "1.4fr 1fr 1fr auto",
+      }}
+    >
+      {/* Header */}
+      <span className="px-3 py-2 text-[11px] uppercase tracking-[.04em] text-muted-foreground">
+        Tienda
+      </span>
+      <span className="px-3 py-2 text-[11px] uppercase tracking-[.04em] text-muted-foreground">
+        Precio
+      </span>
+      <span className="px-3 py-2 text-[11px] uppercase tracking-[.04em] text-muted-foreground">
+        Cuotas
+      </span>
+      <span className="px-3 py-2 text-[11px] uppercase tracking-[.04em] text-muted-foreground">
+        —
+      </span>
+
+      {sorted.map((offer, i) => {
+        const isBest = i === 0;
+        const rowStyle = isBest
+          ? { background: "hsl(var(--price-down-bg))" }
+          : undefined;
+
+        return (
+          <div key={offer.url} className="contents">
+            <span
+              className={`flex items-center gap-1 px-3 py-2 text-sm${offer.stock === false ? "opacity-50" : ""}`}
+              style={rowStyle}
+            >
+              {offer.store}
+            </span>
+            <span
+              className={`flex items-center px-3 py-2 text-sm font-medium${offer.stock === false ? "opacity-50" : ""}`}
+              style={rowStyle}
+            >
+              {isBest && (
+                <span className="mr-1 text-[10px] font-semibold uppercase text-[hsl(var(--price-down))]">
+                  MEJOR PRECIO
+                </span>
+              )}
+              {fmtARS(offer.price)}
+            </span>
+            <span
+              className={`flex items-center px-3 py-2 text-sm${offer.stock === false ? "opacity-50" : ""}`}
+              style={rowStyle}
+            >
+              {offer.installment != null ? `${offer.installment} CSI` : "—"}
+            </span>
+            <span
+              className={`flex items-center px-3 py-2${offer.stock === false ? "opacity-50" : ""}`}
+              style={rowStyle}
+            >
+              <Button
+                size="sm"
+                variant={isBest ? "default" : "outline"}
+                onClick={() => onGoToStore(offer.url)}
+                disabled={offer.stock === false}
+                className="rounded-lg text-xs"
+              >
+                Ver
+              </Button>
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/CompareTable/index.ts
+++ b/src/components/CompareTable/index.ts
@@ -1,0 +1,1 @@
+export { CompareTable } from "./CompareTable";

--- a/src/components/InstallmentBadge/InstallmentBadge.tsx
+++ b/src/components/InstallmentBadge/InstallmentBadge.tsx
@@ -1,0 +1,16 @@
+import { Badge } from "@/components/ui/badge";
+
+interface InstallmentBadgeProps {
+  installment: number;
+}
+
+export function InstallmentBadge({ installment }: InstallmentBadgeProps) {
+  return (
+    <Badge
+      variant="outline"
+      className="border-transparent bg-[hsl(var(--installment))] px-2 py-[3px] font-display text-xs font-medium text-white"
+    >
+      {installment} CSI
+    </Badge>
+  );
+}

--- a/src/components/InstallmentBadge/__tests__/InstallmentBadge.test.tsx
+++ b/src/components/InstallmentBadge/__tests__/InstallmentBadge.test.tsx
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { InstallmentBadge } from "../InstallmentBadge";
+
+describe("InstallmentBadge", () => {
+  it('renders "{n} CSI" where n is the installment prop', () => {
+    const html = renderToStaticMarkup(InstallmentBadge({ installment: 12 }));
+    expect(html).toContain("12 CSI");
+  });
+
+  it("renders with installment=1 without crashing", () => {
+    expect(() =>
+      renderToStaticMarkup(InstallmentBadge({ installment: 1 })),
+    ).not.toThrow();
+  });
+});

--- a/src/components/InstallmentBadge/index.ts
+++ b/src/components/InstallmentBadge/index.ts
@@ -1,0 +1,1 @@
+export { InstallmentBadge } from "./InstallmentBadge";

--- a/src/components/PriceHistory/PriceHistoryChart.tsx
+++ b/src/components/PriceHistory/PriceHistoryChart.tsx
@@ -1,0 +1,133 @@
+import type { PriceHistoryEntry } from "@/features/price-history/types";
+
+interface PriceHistoryChartProps {
+  data: PriceHistoryEntry[];
+  fmt?: (n: number) => string;
+}
+
+const defaultFmt = (n: number) =>
+  n.toLocaleString("es-AR", { style: "currency", currency: "ARS" });
+
+const W = 520;
+const H = 160;
+const PAD = { top: 20, right: 20, bottom: 30, left: 20 };
+
+export function PriceHistoryChart({
+  data,
+  fmt = defaultFmt,
+}: PriceHistoryChartProps) {
+  if (data.length < 2) return null;
+
+  // Convert cents to pesos for display
+  const prices = data.map((e) => e.minPrice / 100);
+  const minPrice = Math.min(...prices);
+  const maxPrice = Math.max(...prices);
+  const priceRange = maxPrice - minPrice || 1;
+
+  const innerW = W - PAD.left - PAD.right;
+  const innerH = H - PAD.top - PAD.bottom;
+
+  const xOf = (i: number) => PAD.left + (i / (data.length - 1)) * innerW;
+  const yOf = (p: number) =>
+    PAD.top + innerH - ((p - minPrice) / priceRange) * innerH;
+
+  const points = prices.map((p, i) => `${xOf(i)},${yOf(p)}`).join(" ");
+
+  const minIdx = prices.indexOf(minPrice);
+  const lastIdx = data.length - 1;
+  const lastPrice = prices[lastIdx];
+
+  const delta =
+    minPrice > 0 ? Math.round(((lastPrice - minPrice) / minPrice) * 100) : 0;
+  const deltaLabel = delta >= 0 ? `+${delta}%` : `${delta}%`;
+
+  const gridPrices = Array.from(
+    { length: 4 },
+    (_, i) => minPrice + (priceRange / 3) * i,
+  );
+
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      width="100%"
+      aria-label="Historial de precios"
+    >
+      {/* Horizontal grid lines */}
+      {gridPrices.map((gp, i) => {
+        const y = yOf(gp);
+        return (
+          <line
+            key={i}
+            x1={PAD.left}
+            y1={y}
+            x2={W - PAD.right}
+            y2={y}
+            stroke="currentColor"
+            strokeOpacity={0.1}
+            strokeWidth={1}
+          />
+        );
+      })}
+
+      {/* Polyline */}
+      <polyline
+        points={points}
+        fill="none"
+        stroke="hsl(var(--primary))"
+        strokeWidth={2}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+
+      {/* Min marker */}
+      <circle
+        cx={xOf(minIdx)}
+        cy={yOf(minPrice)}
+        r={4}
+        fill="hsl(var(--price-down))"
+      />
+
+      {/* Current (last) marker */}
+      <circle
+        cx={xOf(lastIdx)}
+        cy={yOf(lastPrice)}
+        r={4}
+        fill="hsl(var(--primary))"
+      />
+
+      {/* X-axis dates (start and end) */}
+      <text
+        x={PAD.left}
+        y={H - 4}
+        fontSize={9}
+        fill="currentColor"
+        fillOpacity={0.5}
+      >
+        {data[0].date}
+      </text>
+      <text
+        x={W - PAD.right}
+        y={H - 4}
+        fontSize={9}
+        fill="currentColor"
+        fillOpacity={0.5}
+        textAnchor="end"
+      >
+        {data[lastIdx].date}
+      </text>
+
+      {/* Legend */}
+      <g transform={`translate(${PAD.left}, ${PAD.top - 4})`}>
+        <text fontSize={9} fill="currentColor" fillOpacity={0.7}>
+          <tspan fill="hsl(var(--price-down))">Mínimo </tspan>
+          {fmt(minPrice)}
+          {"  "}
+          <tspan fill="hsl(var(--primary))">Actual </tspan>
+          {fmt(lastPrice)}
+          {"  "}
+          {deltaLabel}
+        </text>
+      </g>
+    </svg>
+  );
+}

--- a/src/components/PriceHistory/index.ts
+++ b/src/components/PriceHistory/index.ts
@@ -1,0 +1,1 @@
+export { PriceHistoryChart } from "./PriceHistoryChart";

--- a/src/components/PriceTrend/PriceTrend.tsx
+++ b/src/components/PriceTrend/PriceTrend.tsx
@@ -1,0 +1,29 @@
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface PriceTrendProps {
+  direction: "up" | "down";
+  delta: number;
+  label?: string;
+}
+
+export function PriceTrend({ direction, delta, label }: PriceTrendProps) {
+  const isDown = direction === "down";
+
+  return (
+    <span className="inline-flex items-center gap-1">
+      <Badge
+        variant="outline"
+        className={cn(
+          "border-transparent px-2 py-[3px] text-xs font-medium",
+          isDown
+            ? "bg-[hsl(var(--price-down-bg))] text-[hsl(var(--price-down))]"
+            : "bg-[hsl(var(--price-up-bg))] text-[hsl(var(--price-up))]",
+        )}
+      >
+        {isDown ? "↓" : "↑"} {delta}%
+      </Badge>
+      {label && <span className="text-xs text-muted-foreground">{label}</span>}
+    </span>
+  );
+}

--- a/src/components/PriceTrend/__tests__/PriceTrend.test.tsx
+++ b/src/components/PriceTrend/__tests__/PriceTrend.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * @jest-environment node
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { PriceTrend } from "../PriceTrend";
+
+describe("PriceTrend", () => {
+  it("down badge uses --price-down and --price-down-bg CSS vars", () => {
+    const html = renderToStaticMarkup(
+      PriceTrend({ direction: "down", delta: 5 }),
+    );
+    expect(html).toContain("--price-down-bg");
+    expect(html).toContain("--price-down");
+  });
+
+  it("up badge uses --price-up and --price-up-bg CSS vars", () => {
+    const html = renderToStaticMarkup(
+      PriceTrend({ direction: "up", delta: 3 }),
+    );
+    expect(html).toContain("--price-up-bg");
+    expect(html).toContain("--price-up");
+  });
+
+  it('renders "0%" when delta=0', () => {
+    const html = renderToStaticMarkup(
+      PriceTrend({ direction: "down", delta: 0 }),
+    );
+    expect(html).toContain("0%");
+  });
+
+  it("renders label adjacent when provided", () => {
+    const html = renderToStaticMarkup(
+      PriceTrend({ direction: "down", delta: 5, label: "vs mín" }),
+    );
+    expect(html).toContain("vs mín");
+  });
+});

--- a/src/components/PriceTrend/index.ts
+++ b/src/components/PriceTrend/index.ts
@@ -1,0 +1,1 @@
+export { PriceTrend } from "./PriceTrend";

--- a/src/components/ProductDetail/ProductDetail.tsx
+++ b/src/components/ProductDetail/ProductDetail.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { PriceTrend } from "@/components/PriceTrend";
+import { InstallmentBadge } from "@/components/InstallmentBadge";
+import { CompareTable } from "@/components/CompareTable";
+import { PriceHistoryChart } from "@/components/PriceHistory";
+import { matchOffers } from "@/features/price-search/match";
+import { fetchPriceHistory } from "@/features/price-history/history";
+import { useProductsStore } from "@/store/productsStore";
+import { imageLoader } from "@/features/price-search/image-loader";
+import type { Product } from "@/types/product.d";
+import type { PriceHistoryEntry } from "@/features/price-history/types";
+import type { TrendMap } from "@/features/price-history/types";
+
+interface ProductDetailProps {
+  product: Product | null;
+  open: boolean;
+  onClose: () => void;
+  currentQuery: string;
+  trendMap?: TrendMap;
+}
+
+const fmtARS = (n: number) =>
+  n.toLocaleString("es-AR", { style: "currency", currency: "ARS" });
+
+export function ProductDetail({
+  product,
+  open,
+  onClose,
+  currentQuery,
+  trendMap = {},
+}: ProductDetailProps) {
+  const allProducts = useProductsStore((s) => s.products);
+  const [priceHistory, setPriceHistory] = useState<PriceHistoryEntry[]>([]);
+
+  useEffect(() => {
+    if (!open || !currentQuery) return;
+    fetchPriceHistory(currentQuery).then(setPriceHistory);
+  }, [open, currentQuery]);
+
+  if (!product) return null;
+
+  const offers = matchOffers(product, allProducts);
+  const trend = product.url
+    ? (trendMap[product.url] ?? trendMap["__global__"])
+    : undefined;
+
+  return (
+    <Sheet
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) onClose();
+      }}
+    >
+      <SheetContent side="right" className="overflow-y-auto p-0">
+        <SheetHeader className="sr-only">
+          <SheetTitle>{product.name ?? "Detalle del producto"}</SheetTitle>
+        </SheetHeader>
+
+        {/* Hero */}
+        <div className="flex flex-col gap-4 p-6">
+          {/* Product image */}
+          <div className="relative h-[200px] w-full overflow-hidden rounded-xl bg-[hsl(var(--surface))]">
+            <Image
+              loader={imageLoader}
+              src={product.image || "/placeholder.png"}
+              alt={product.name ?? "Producto"}
+              fill
+              sizes="480px"
+              className="object-contain p-4"
+            />
+          </div>
+
+          {/* Store badge */}
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="secondary"
+              className="rounded-full text-[11px] font-semibold"
+            >
+              {product.from}
+            </Badge>
+          </div>
+
+          {/* Brand */}
+          {product.brand && (
+            <p className="font-display text-xs font-semibold uppercase tracking-[0.04em] text-muted-foreground">
+              {product.brand}
+            </p>
+          )}
+
+          {/* Name */}
+          {product.name && (
+            <h2 className="font-display text-lg font-bold text-foreground">
+              {product.name}
+            </h2>
+          )}
+
+          {/* Price + trend + installment */}
+          <div className="flex flex-wrap items-center gap-2">
+            {product.price != null && (
+              <p
+                className="font-display text-2xl font-bold"
+                style={{ color: "hsl(var(--price-green))" }}
+              >
+                {fmtARS(product.price)}
+              </p>
+            )}
+            {trend && (
+              <PriceTrend
+                direction={trend.direction}
+                delta={trend.delta}
+                label="vs ayer"
+              />
+            )}
+            {product.installment != null && (
+              <InstallmentBadge installment={product.installment} />
+            )}
+          </div>
+
+          {/* Primary CTA */}
+          <Button
+            onClick={() => product.url && window.open(product.url, "_blank")}
+            className="w-full rounded-xl py-3"
+          >
+            Ir a {product.from}
+          </Button>
+
+          {/* Seguir precio — disabled with tooltip */}
+          <Button
+            variant="outline"
+            disabled
+            title="Próximamente"
+            className="w-full rounded-xl py-3"
+          >
+            Seguir precio
+          </Button>
+        </div>
+
+        {/* Divider */}
+        <div className="h-px bg-border" />
+
+        {/* CompareTable */}
+        {offers.length > 0 && (
+          <div className="p-6">
+            <p className="mb-3 text-xs font-semibold uppercase tracking-[0.04em] text-muted-foreground">
+              Comparar precios
+            </p>
+            <CompareTable
+              offers={offers}
+              onGoToStore={(url) => window.open(url, "_blank")}
+            />
+          </div>
+        )}
+
+        {/* Divider */}
+        <div className="h-px bg-border" />
+
+        {/* PriceHistoryChart */}
+        <div className="p-6">
+          <p className="mb-3 text-xs font-semibold uppercase tracking-[0.04em] text-muted-foreground">
+            Historial de precios
+          </p>
+          <PriceHistoryChart data={priceHistory} />
+          {priceHistory.length < 2 && (
+            <p className="text-xs text-muted-foreground">
+              No hay suficiente historial para mostrar el gráfico.
+            </p>
+          )}
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/src/components/ProductDetail/index.ts
+++ b/src/components/ProductDetail/index.ts
@@ -1,0 +1,1 @@
+export { ProductDetail } from "./ProductDetail";

--- a/src/components/ProductList/ProductList.tsx
+++ b/src/components/ProductList/ProductList.tsx
@@ -1,6 +1,5 @@
 "use client";
 import Image from "next/image";
-import Link from "next/link";
 import { imageLoader } from "@/features/price-search/image-loader";
 import { useProductsStore } from "@/store/productsStore";
 import { loadingMessages } from "@/features/price-search/loading-messages";
@@ -8,10 +7,12 @@ import { useEffect, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { EmptyState } from "@/components/EmptyState";
 import { ErrorAlert } from "@/components/ErrorAlert";
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
 import { fetchTrendMap } from "@/features/price-history/trend";
+import { PriceTrend } from "@/components/PriceTrend";
+import { InstallmentBadge } from "@/components/InstallmentBadge";
+import { ProductDetail } from "@/components/ProductDetail";
 import type { TrendMap } from "@/features/price-history/types";
+import type { Product } from "@/types/product.d";
 
 const ITEMS_PER_PAGE = 12;
 
@@ -46,6 +47,7 @@ export default function ProductList() {
   const [currentPage, setCurrentPage] = useState(1);
   const [prevProductsRef, setPrevProductsRef] = useState(products);
   const [trendMap, setTrendMap] = useState<TrendMap>({});
+  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
 
   if (prevProductsRef !== products) {
     setPrevProductsRef(products);
@@ -102,6 +104,8 @@ export default function ProductList() {
 
   if (visible.length === 0) return null;
 
+  const globalTrend = trendMap["__global__"];
+
   return (
     <div className="flex flex-col gap-4">
       <ErrorAlert />
@@ -110,12 +114,11 @@ export default function ProductList() {
         {paginatedProducts.map((product) => {
           if (!product.price || !product.name || !product.url) return null;
           return (
-            <Link
+            <div
               key={product.url}
-              href={product.url}
-              target="_blank"
               data-testid="product-card"
-              className="flex flex-col overflow-hidden rounded-xl border border-border bg-card transition-all duration-150 hover:-translate-y-[3px] hover:border-transparent hover:shadow-pop"
+              onClick={() => setSelectedProduct(product)}
+              className="flex cursor-pointer flex-col overflow-hidden rounded-xl border border-border bg-card transition-all duration-150 hover:-translate-y-[3px] hover:border-transparent hover:shadow-pop"
             >
               <div className="relative h-[140px] w-full overflow-hidden bg-surface">
                 <Image
@@ -147,36 +150,24 @@ export default function ProductList() {
                     currency: "ARS",
                   })}
                 </p>
-                {trendMap["__global__"] && (
-                  <Badge
-                    variant="outline"
-                    className={cn(
-                      "w-fit text-xs font-medium",
-                      trendMap["__global__"].direction === "down"
-                        ? "border-green-200 bg-green-500/10 text-green-700 dark:border-green-800 dark:bg-green-500/10 dark:text-green-400"
-                        : "border-red-200 bg-red-500/10 text-red-700 dark:border-red-900 dark:bg-red-500/10 dark:text-red-400",
-                    )}
-                  >
-                    {trendMap["__global__"].direction === "down" ? "↓" : "↑"}{" "}
-                    {trendMap["__global__"].delta}% vs ayer
-                  </Badge>
+                {globalTrend && (
+                  <PriceTrend
+                    direction={globalTrend.direction}
+                    delta={globalTrend.delta}
+                    label="vs ayer"
+                  />
                 )}
                 <div className="h-px bg-border" />
                 <div className="flex flex-wrap items-start gap-[6px]">
                   <span className="font-display text-xs font-semibold uppercase tracking-[0.02em] text-muted-foreground">
                     {product.brand}
                   </span>
-                  {product.installment ? (
-                    <span
-                      data-testid="product-installment"
-                      className="rounded-md bg-orange-500 px-2 py-[3px] text-xs font-medium text-white"
-                    >
-                      {product.installment} CSI
-                    </span>
-                  ) : null}
+                  {product.installment != null && (
+                    <InstallmentBadge installment={product.installment} />
+                  )}
                 </div>
               </div>
-            </Link>
+            </div>
           );
         })}
       </div>
@@ -240,6 +231,14 @@ export default function ProductList() {
           </button>
         </div>
       )}
+
+      <ProductDetail
+        product={selectedProduct}
+        open={selectedProduct !== null}
+        onClose={() => setSelectedProduct(null)}
+        currentQuery={currentQuery}
+        trendMap={trendMap}
+      />
     </div>
   );
 }

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { Cross2Icon } from "@radix-ui/react-icons";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = DialogPrimitive.Root;
+
+const SheetTrigger = DialogPrimitive.Trigger;
+
+const SheetClose = DialogPrimitive.Close;
+
+const SheetPortal = DialogPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = "SheetOverlay";
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  side?: "right" | "left" | "top" | "bottom";
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  SheetContentProps
+>(({ className, children, side = "right", ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        side === "right" && [
+          "inset-y-0 right-0 h-full w-full sm:max-w-[480px]",
+          "data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+          "duration-300",
+        ],
+        side === "left" && [
+          "inset-y-0 left-0 h-full w-full sm:max-w-[480px]",
+          "data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left",
+          "duration-300",
+        ],
+        side === "top" && [
+          "inset-x-0 top-0 h-auto",
+          "data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          "duration-300",
+        ],
+        side === "bottom" && [
+          "inset-x-0 bottom-0 h-auto",
+          "data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          "duration-300",
+        ],
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent">
+        <Cross2Icon className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = "SheetContent";
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-1.5 p-6 pb-0", className)}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className,
+    )}
+    {...props}
+  />
+));
+SheetTitle.displayName = "SheetTitle";
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetClose,
+};

--- a/src/features/price-history/__tests__/history.test.ts
+++ b/src/features/price-history/__tests__/history.test.ts
@@ -1,0 +1,58 @@
+import { fetchPriceHistory } from "../history";
+
+global.fetch = jest.fn();
+const mockFetch = global.fetch as jest.Mock;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("fetchPriceHistory", () => {
+  it("calls /api/prices/history?query=... with the encoded query", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    await fetchPriceHistory("iphone 15");
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/prices/history?query=iphone%2015",
+    );
+  });
+
+  it("returns PriceHistoryEntry[] sorted ASC (reverses DESC API response)", async () => {
+    const descEntries = [
+      { date: "2026-06-21", minPrice: 300000 },
+      { date: "2026-06-20", minPrice: 290000 },
+      { date: "2026-06-19", minPrice: 280000 },
+    ];
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => descEntries,
+    });
+
+    const result = await fetchPriceHistory("iphone");
+    expect(result).toHaveLength(3);
+    expect(result[0].date).toBe("2026-06-19");
+    expect(result[1].date).toBe("2026-06-20");
+    expect(result[2].date).toBe("2026-06-21");
+  });
+
+  it("returns [] if fetch throws (network error)", async () => {
+    mockFetch.mockRejectedValue(new Error("Network error"));
+    const result = await fetchPriceHistory("iphone");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] if response is not OK", async () => {
+    mockFetch.mockResolvedValue({ ok: false });
+    const result = await fetchPriceHistory("iphone");
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] if response is an empty array", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    });
+    const result = await fetchPriceHistory("iphone");
+    expect(result).toEqual([]);
+  });
+});

--- a/src/features/price-history/history.ts
+++ b/src/features/price-history/history.ts
@@ -1,0 +1,20 @@
+import type { PriceHistoryEntry } from "./types";
+
+export async function fetchPriceHistory(
+  query: string,
+): Promise<PriceHistoryEntry[]> {
+  try {
+    const res = await fetch(
+      `/api/prices/history?query=${encodeURIComponent(query)}`,
+    );
+    if (!res.ok) return [];
+
+    const entries: PriceHistoryEntry[] = await res.json();
+    if (!Array.isArray(entries) || entries.length === 0) return [];
+
+    // API returns DESC (newest first); reverse to ASC for charting
+    return [...entries].reverse();
+  } catch {
+    return [];
+  }
+}

--- a/src/features/price-search/__tests__/match.test.ts
+++ b/src/features/price-search/__tests__/match.test.ts
@@ -1,0 +1,132 @@
+import { matchOffers } from "../match";
+import { StoreNamesEnum } from "@/enums/stores.enum";
+import type { Product } from "@/types/product.d";
+
+const makeProduct = (
+  overrides: Partial<Product> & { from: StoreNamesEnum },
+): Product => ({
+  name: undefined,
+  price: undefined,
+  image: "",
+  url: undefined,
+  brand: "",
+  ...overrides,
+});
+
+const clicked: Product = {
+  from: StoreNamesEnum.FRAVEGA,
+  name: "Samsung Galaxy S24 256GB Negro",
+  price: 100000,
+  image: "",
+  url: "https://fravega.com/s24",
+  brand: "Samsung",
+  installment: 12,
+};
+
+describe("matchOffers", () => {
+  it("always includes the clicked product (same url)", () => {
+    const result = matchOffers(clicked, [clicked]);
+    expect(result.some((o) => o.url === clicked.url)).toBe(true);
+  });
+
+  it("excludes candidates from the same store (same from)", () => {
+    const sameStore: Product = {
+      ...clicked,
+      url: "https://fravega.com/s24-variant",
+      price: 90000,
+    };
+    const result = matchOffers(clicked, [clicked, sameStore]);
+    expect(
+      result.filter((o) => o.store === StoreNamesEnum.FRAVEGA),
+    ).toHaveLength(1);
+  });
+
+  it("matches if all numeric tokens from clicked are in candidate and >=2 text tokens overlap", () => {
+    const candidate: Product = {
+      from: StoreNamesEnum.NALDO,
+      name: "Samsung Galaxy S24 256GB Blanco",
+      price: 95000,
+      image: "",
+      url: "https://naldo.com/s24",
+      brand: "Samsung",
+    };
+    const result = matchOffers(clicked, [clicked, candidate]);
+    expect(result.some((o) => o.url === candidate.url)).toBe(true);
+  });
+
+  it("does NOT match if numeric tokens differ (e.g. 256GB vs 512GB)", () => {
+    const candidate512: Product = {
+      from: StoreNamesEnum.CETROGAR,
+      name: "Samsung Galaxy S24 512GB Negro",
+      price: 120000,
+      image: "",
+      url: "https://cetrogar.com/s24-512",
+      brand: "Samsung",
+    };
+    const result = matchOffers(clicked, [clicked, candidate512]);
+    expect(result.some((o) => o.url === candidate512.url)).toBe(false);
+  });
+
+  it("does NOT match if fewer than 2 text tokens overlap", () => {
+    const unrelated: Product = {
+      from: StoreNamesEnum.CARREFOUR,
+      name: "Samsung TV 55 pulgadas",
+      price: 80000,
+      image: "",
+      url: "https://carrefour.com/tv",
+      brand: "Samsung",
+    };
+    const result = matchOffers(clicked, [clicked, unrelated]);
+    expect(result.some((o) => o.url === unrelated.url)).toBe(false);
+  });
+
+  it("returns results sorted by price asc", () => {
+    const cheap: Product = {
+      from: StoreNamesEnum.NALDO,
+      name: "Samsung Galaxy S24 256GB Azul",
+      price: 85000,
+      image: "",
+      url: "https://naldo.com/s24",
+      brand: "Samsung",
+    };
+    const expensive: Product = {
+      from: StoreNamesEnum.CETROGAR,
+      name: "Samsung Galaxy S24 256GB Rojo",
+      price: 110000,
+      image: "",
+      url: "https://cetrogar.com/s24",
+      brand: "Samsung",
+    };
+    const result = matchOffers(clicked, [clicked, expensive, cheap]);
+    const prices = result.map((o) => o.price);
+    expect(prices[0]).toBeLessThanOrEqual(prices[1]!);
+    expect(prices[1]).toBeLessThanOrEqual(prices[2]!);
+  });
+
+  it("does not crash when name is undefined", () => {
+    const noName: Product = makeProduct({
+      from: StoreNamesEnum.NALDO,
+      price: 80000,
+      url: "https://naldo.com/x",
+    });
+    expect(() => matchOffers(clicked, [clicked, noName])).not.toThrow();
+  });
+
+  it("does not crash when price is undefined; undefined price sorts last", () => {
+    const noPrice: Product = {
+      from: StoreNamesEnum.NALDO,
+      name: "Samsung Galaxy S24 256GB Verde",
+      price: undefined,
+      image: "",
+      url: "https://naldo.com/s24-noprice",
+      brand: "Samsung",
+    };
+    const result = matchOffers(clicked, [clicked, noPrice]);
+    if (result.some((o) => o.url === noPrice.url)) {
+      const idx = result.findIndex((o) => o.url === noPrice.url);
+      const lastIdx = result.length - 1;
+      expect(idx).toBe(lastIdx);
+    }
+    expect(() => matchOffers(clicked, [clicked, noPrice])).not.toThrow();
+  });
+});

--- a/src/features/price-search/match.ts
+++ b/src/features/price-search/match.ts
@@ -1,0 +1,115 @@
+import type { Product } from "@/types/product.d";
+
+export interface CompareOffer {
+  store: string;
+  price: number;
+  url: string;
+  installment?: number;
+  stock: boolean;
+}
+
+const STOP_WORDS = new Set([
+  "de",
+  "la",
+  "el",
+  "los",
+  "las",
+  "y",
+  "en",
+  "con",
+  "para",
+  "a",
+  "e",
+]);
+
+function normalize(name: string): string {
+  return name
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "")
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function tokenize(name: string): { numeric: string[]; text: string[] } {
+  const normalized = normalize(name);
+  const parts = normalized.split(" ");
+  const numeric: string[] = [];
+  const text: string[] = [];
+
+  for (let i = 0; i < parts.length; i++) {
+    const token = parts[i];
+    if (/\d/.test(token)) {
+      // Join with next token if it looks like a unit (letters only, no digits)
+      const next = parts[i + 1];
+      if (next && /^[a-z]+$/.test(next) && next.length <= 2) {
+        numeric.push(token + next);
+        i++;
+      } else {
+        numeric.push(token);
+      }
+    } else if (/^[a-z]{2,}$/.test(token) && !STOP_WORDS.has(token)) {
+      text.push(token);
+    }
+  }
+
+  return { numeric, text };
+}
+
+export function matchOffers(
+  clicked: Product,
+  allProducts: Product[],
+): CompareOffer[] {
+  const clickedName = clicked.name ?? "";
+  const clickedTokens = tokenize(clickedName);
+
+  const offers: CompareOffer[] = [];
+
+  for (const candidate of allProducts) {
+    // Always include the clicked product itself
+    if (candidate.url === clicked.url) {
+      offers.push({
+        store: candidate.from,
+        price: candidate.price ?? Infinity,
+        url: candidate.url ?? "",
+        installment: candidate.installment,
+        stock: true,
+      });
+      continue;
+    }
+
+    // Exclude same store
+    if (candidate.from === clicked.from) continue;
+
+    const candidateName = candidate.name ?? "";
+    const candidateTokens = tokenize(candidateName);
+
+    // All clicked numeric tokens must be present in candidate numeric tokens
+    const candidateNumericSet = new Set(candidateTokens.numeric);
+    const allNumericMatch = clickedTokens.numeric.every((t) =>
+      candidateNumericSet.has(t),
+    );
+    if (clickedTokens.numeric.length > 0 && !allNumericMatch) continue;
+
+    // At least 2 text tokens must overlap
+    const candidateTextSet = new Set(candidateTokens.text);
+    const textOverlap = clickedTokens.text.filter((t) =>
+      candidateTextSet.has(t),
+    ).length;
+    if (textOverlap < 2) continue;
+
+    offers.push({
+      store: candidate.from,
+      price: candidate.price ?? Infinity,
+      url: candidate.url ?? "",
+      installment: candidate.installment,
+      stock: true,
+    });
+  }
+
+  // Sort by price ascending (Infinity sorts last)
+  offers.sort((a, b) => a.price - b.price);
+
+  return offers;
+}


### PR DESCRIPTION
## Summary

- **Sheet primitive** (`src/components/ui/sheet.tsx`) built from `@radix-ui/react-dialog`, siguiendo el patrón shadcn/ui con animación slide-in desde la derecha
- **`matchOffers`** (`src/features/price-search/match.ts`) — algoritmo de matching cross-store por tokens numéricos (obligatorio: `256gb` ≠ `512gb`) + ≥2 tokens de texto en común
- **`fetchPriceHistory`** (`src/features/price-history/history.ts`) — wrapper de `/api/prices/history` con sort ASC
- **`PriceTrend`** / **`InstallmentBadge`** — badges usando `shadcn/ui Badge` con CSS vars del DS
- **`CompareTable`** — grid 4 columnas, primera fila (mejor precio) resaltada con `--price-down-bg`, CTAs con `shadcn/ui Button`
- **`PriceHistoryChart`** — SVG puro, convierte `minPrice` de centavos a pesos (`/100`)
- **`ProductDetail`** — Sheet composición completa: hero, CTAs con `Button`, compare table, historial de precios
- **`ProductList`** modificado: card click abre el Sheet; badges inline reemplazados por `PriceTrend` e `InstallmentBadge`

## Test plan

- [x] 183 Jest tests GREEN (`npm test`)
- [x] TypeScript build limpio (`npm run build`)
- [x] ESLint + Prettier sin errores (pre-commit hook)
- [x] E2E spec creado (`e2e/product-detail.spec.ts`): sheet open/close, CTA nueva pestaña
- [x] TDD aplicado: ciclo RED→GREEN para `matchOffers`, `fetchPriceHistory`, `PriceTrend`, `InstallmentBadge`