### PR TITLE
feat(ui): close DS gaps — CategoryChips, Disclaimer gate, ProductDetailPanel, MissionModal

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,7 @@ import { FilterPanel } from "@/components/FilterPanel";
 import SearchRow from "@/components/SearchRow";
 import { Header } from "@/components/Header";
 import { ResultsHeader } from "@/components/ResultsHeader";
-import CategoryChips from "@/components/CategoryChips";
+import { CategoryChips } from "@/components/CategoryChips";
 import { ResultsOrchestrator } from "@/components/ResultsOrchestrator/ResultsOrchestrator";
 
 export default async function Home() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,35 +6,42 @@ import { FilterPanel } from "@/components/FilterPanel";
 import SearchRow from "@/components/SearchRow";
 import { Header } from "@/components/Header";
 import { ResultsHeader } from "@/components/ResultsHeader";
+import CategoryChips from "@/components/CategoryChips";
+import { ResultsOrchestrator } from "@/components/ResultsOrchestrator/ResultsOrchestrator";
 
 export default async function Home() {
   return (
-    <main className="min-h-screen flex flex-col">
+    <main className="flex min-h-screen flex-col">
       <Header />
-      <div className="w-full h-px bg-border shrink-0" />
+      <div className="h-px w-full shrink-0 bg-border" />
 
-      <div className="w-full max-w-[1280px] flex flex-col mx-auto px-4 sm:px-10 lg:px-20 pt-6 lg:pt-10 pb-10 lg:pb-16 flex-1 gap-5 lg:gap-8">
+      <div className="mx-auto flex w-full max-w-[1280px] flex-1 flex-col gap-5 px-4 pb-10 pt-6 sm:px-10 lg:gap-8 lg:px-20 lg:pb-16 lg:pt-10">
         {/* Hero */}
-        <section className="flex flex-col items-stretch sm:items-center gap-[10px] sm:gap-4 pt-2 pb-4 sm:pt-6 sm:pb-8">
-          <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold tracking-tight text-center">
+        <section className="flex flex-col items-stretch gap-[10px] pb-4 pt-2 sm:items-center sm:gap-4 sm:pb-8 sm:pt-6">
+          <h1 className="text-center text-2xl font-bold tracking-tight sm:text-3xl lg:text-4xl">
             ¿Quién da menos?
           </h1>
-          <p className="text-muted-foreground text-sm sm:text-base text-center max-w-lg">
-            <span className="sm:hidden">Buscá y comparamos en Frávega, Cetrogar y más</span>
+          <p className="max-w-lg text-center text-sm text-muted-foreground sm:text-base">
+            <span className="sm:hidden">
+              Buscá y comparamos en Frávega, Cetrogar y más
+            </span>
             <span className="hidden sm:inline">
               Buscá una vez y comparamos en Frávega, Cetrogar, Musimundo,
               Megatone y más — al mismo tiempo.
             </span>
           </p>
           <SearchRow />
+          <CategoryChips />
         </section>
 
         <Disclaimer />
 
-        <FilterPanel />
-        <StoresList />
-        <ResultsHeader />
-        <ProductList />
+        <ResultsOrchestrator>
+          <FilterPanel />
+          <StoresList />
+          <ResultsHeader />
+          <ProductList />
+        </ResultsOrchestrator>
       </div>
 
       <Footer />

--- a/src/components/CategoryChips/CategoryChips.tsx
+++ b/src/components/CategoryChips/CategoryChips.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useProductsStore, selectPhase } from "@/store/productsStore";
+import { useShallow } from "zustand/react/shallow";
+
+interface Category {
+  label: string;
+  query: string;
+}
+
+const CATEGORIES: Category[] = [
+  { label: "Celulares", query: "celular" },
+  { label: "Tablets", query: "tablet" },
+  { label: "TVs", query: "tv" },
+  { label: "Auriculares", query: "auriculares" },
+  { label: "Notebooks", query: "notebook" },
+  { label: "Consolas", query: "consola" },
+  { label: "Heladeras", query: "heladera" },
+  { label: "Lavadoras", query: "lavarropas" },
+];
+
+export default function CategoryChips() {
+  const { getProducts, phase } = useProductsStore(
+    useShallow((s) => ({
+      getProducts: s.getProducts,
+      phase: selectPhase(s),
+    })),
+  );
+
+  if (phase === "results") return null;
+
+  return (
+    <div className="flex flex-wrap justify-center gap-2">
+      {CATEGORIES.map((cat) => (
+        <button
+          key={cat.label}
+          onClick={() => getProducts(cat.query)}
+          className="rounded-full bg-secondary px-4 py-1.5 text-sm font-medium text-secondary-foreground transition-colors hover:bg-secondary/80"
+        >
+          {cat.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/CategoryChips/__tests__/CategoryChips.test.tsx
+++ b/src/components/CategoryChips/__tests__/CategoryChips.test.tsx
@@ -1,0 +1,98 @@
+/** @jest-environment node */
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+const mockGetProducts = jest.fn();
+
+jest.mock("@/store/productsStore", () => ({
+  useProductsStore: jest.fn(),
+  selectPhase: jest.fn(),
+}));
+
+jest.mock("zustand/react/shallow", () => ({
+  useShallow: (fn: (s: unknown) => unknown) => fn,
+}));
+
+import { useProductsStore, selectPhase } from "@/store/productsStore";
+const mockUseStore = useProductsStore as jest.Mock;
+const mockSelectPhase = selectPhase as jest.Mock;
+
+import CategoryChips from "../CategoryChips";
+
+const EXPECTED_CATEGORIES = [
+  "Celulares",
+  "Tablets",
+  "TVs",
+  "Auriculares",
+  "Notebooks",
+  "Consolas",
+  "Heladeras",
+  "Lavadoras",
+];
+
+describe("CategoryChips — landing phase", () => {
+  beforeEach(() => {
+    mockSelectPhase.mockImplementation(() => "landing");
+    mockUseStore.mockImplementation(
+      (
+        selector: (s: {
+          productSearched: string;
+          products: unknown[];
+          isLoading: boolean;
+          getProducts: typeof mockGetProducts;
+        }) => unknown,
+      ) => {
+        const state = {
+          productSearched: "",
+          products: [],
+          isLoading: false,
+          getProducts: mockGetProducts,
+        };
+        return selector(state);
+      },
+    );
+  });
+
+  it("renders all 8 category chips when in landing phase", () => {
+    const html = renderToStaticMarkup(React.createElement(CategoryChips));
+    EXPECTED_CATEGORIES.forEach((cat) => {
+      expect(html).toContain(cat);
+    });
+  });
+
+  it("renders exactly 8 buttons", () => {
+    const html = renderToStaticMarkup(React.createElement(CategoryChips));
+    const matches = html.match(/<button/g);
+    expect(matches).not.toBeNull();
+    expect(matches!.length).toBe(8);
+  });
+});
+
+describe("CategoryChips — results phase", () => {
+  beforeEach(() => {
+    mockSelectPhase.mockImplementation(() => "results");
+    mockUseStore.mockImplementation(
+      (
+        selector: (s: {
+          productSearched: string;
+          products: unknown[];
+          isLoading: boolean;
+          getProducts: typeof mockGetProducts;
+        }) => unknown,
+      ) => {
+        const state = {
+          productSearched: "celular",
+          products: [{}],
+          isLoading: false,
+          getProducts: mockGetProducts,
+        };
+        return selector(state);
+      },
+    );
+  });
+
+  it("returns empty string when in results phase", () => {
+    const html = renderToStaticMarkup(React.createElement(CategoryChips));
+    expect(html).toBe("");
+  });
+});

--- a/src/components/CategoryChips/__tests__/CategoryChips.test.tsx
+++ b/src/components/CategoryChips/__tests__/CategoryChips.test.tsx
@@ -14,8 +14,8 @@ jest.mock("zustand/react/shallow", () => ({
 }));
 
 import { useProductsStore, selectPhase } from "@/store/productsStore";
-const mockUseStore = useProductsStore as jest.Mock;
-const mockSelectPhase = selectPhase as jest.Mock;
+const mockUseStore = useProductsStore as unknown as jest.Mock;
+const mockSelectPhase = selectPhase as unknown as jest.Mock;
 
 import CategoryChips from "../CategoryChips";
 

--- a/src/components/CategoryChips/index.ts
+++ b/src/components/CategoryChips/index.ts
@@ -1,0 +1,1 @@
+export { default as CategoryChips } from "./CategoryChips";

--- a/src/components/Disclaimer/Disclaimer.tsx
+++ b/src/components/Disclaimer/Disclaimer.tsx
@@ -1,9 +1,12 @@
 "use client";
 import { useState } from "react";
+import { useProductsStore } from "@/store/productsStore";
 
 export default function Disclaimer() {
   const [visible, setVisible] = useState(true);
+  const productSearched = useProductsStore((s) => s.productSearched);
 
+  if (productSearched === "") return null;
   if (!visible) return null;
 
   return (

--- a/src/components/Disclaimer/__tests__/Disclaimer.test.tsx
+++ b/src/components/Disclaimer/__tests__/Disclaimer.test.tsx
@@ -1,0 +1,41 @@
+/** @jest-environment node */
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+jest.mock("@/store/productsStore", () => ({
+  useProductsStore: jest.fn(),
+}));
+
+import { useProductsStore } from "@/store/productsStore";
+const mockUseStore = useProductsStore as jest.Mock;
+
+import Disclaimer from "../Disclaimer";
+
+describe("Disclaimer — phase gate", () => {
+  it("returns empty string when productSearched is empty (landing phase)", () => {
+    mockUseStore.mockImplementation(
+      (selector: (s: { productSearched: string }) => unknown) =>
+        selector({ productSearched: "" }),
+    );
+    const html = renderToStaticMarkup(React.createElement(Disclaimer));
+    expect(html).toBe("");
+  });
+
+  it("renders the disclaimer content when productSearched is non-empty (results phase)", () => {
+    mockUseStore.mockImplementation(
+      (selector: (s: { productSearched: string }) => unknown) =>
+        selector({ productSearched: "celular" }),
+    );
+    const html = renderToStaticMarkup(React.createElement(Disclaimer));
+    expect(html).toContain("¿Cómo funciona?");
+  });
+
+  it("renders the disclaimer for any non-empty productSearched value", () => {
+    mockUseStore.mockImplementation(
+      (selector: (s: { productSearched: string }) => unknown) =>
+        selector({ productSearched: "notebook" }),
+    );
+    const html = renderToStaticMarkup(React.createElement(Disclaimer));
+    expect(html).toContain("¿Cómo funciona?");
+  });
+});

--- a/src/components/Disclaimer/__tests__/Disclaimer.test.tsx
+++ b/src/components/Disclaimer/__tests__/Disclaimer.test.tsx
@@ -7,7 +7,7 @@ jest.mock("@/store/productsStore", () => ({
 }));
 
 import { useProductsStore } from "@/store/productsStore";
-const mockUseStore = useProductsStore as jest.Mock;
+const mockUseStore = useProductsStore as unknown as jest.Mock;
 
 import Disclaimer from "../Disclaimer";
 

--- a/src/components/MissionModal/MissionModal.tsx
+++ b/src/components/MissionModal/MissionModal.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogHeader,
   DialogTitle,
@@ -11,30 +12,33 @@ export default function MissionModal() {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <button className="bg-primary h-10 px-4 rounded-md text-sm font-semibold text-primary-foreground uppercase">
+        <button className="h-10 rounded-md bg-primary px-4 text-sm font-semibold uppercase text-primary-foreground">
           ¿Quién da menos?
         </button>
       </DialogTrigger>
 
-      <DialogContent className="max-w-[425px] p-6 rounded-xl flex flex-col gap-4">
-        <DialogHeader className="p-0 space-y-0">
+      <DialogContent className="flex max-w-[425px] flex-col gap-4 rounded-xl p-6 [&>button.absolute]:hidden">
+        <DialogHeader className="flex flex-row items-center justify-between space-y-0 p-0">
           <DialogTitle className="text-xl font-bold text-foreground">
             ¿Quién da menos?
           </DialogTitle>
+          <DialogClose className="flex h-7 w-7 items-center justify-center rounded-sm bg-secondary text-muted-foreground hover:bg-secondary/80">
+            <span className="select-none text-base leading-none">×</span>
+          </DialogClose>
         </DialogHeader>
 
-        <p className="text-sm text-muted-foreground leading-[1.6]">
+        <p className="text-sm leading-[1.6] text-muted-foreground">
           Creemos en la transparencia y en la posibilidad de ofrecer a los
           consumidores las mejores opciones de compra.
         </p>
 
-        <p className="text-sm text-muted-foreground leading-[1.6]">
+        <p className="text-sm leading-[1.6] text-muted-foreground">
           Invitamos a todas las empresas y tiendas a compartir sus APIs con
           nosotros para participar en una plataforma donde la competencia se
           basa en la calidad y los precios más bajos.
         </p>
 
-        <div className="flex gap-1 items-center justify-end flex-wrap text-sm">
+        <div className="flex flex-wrap items-center justify-end gap-1 text-sm">
           <span className="text-muted-foreground">
             Con mucho esfuerzo y dedicación,
           </span>

--- a/src/components/MissionModal/__tests__/MissionModal.test.tsx
+++ b/src/components/MissionModal/__tests__/MissionModal.test.tsx
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+// Mock Radix Dialog primitives
+jest.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", { "data-testid": "dialog" }, children),
+  DialogTrigger: ({ children }: { children: React.ReactNode }) =>
+    React.createElement("div", { "data-testid": "dialog-trigger" }, children),
+  DialogContent: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "dialog-content", className },
+      children,
+    ),
+  DialogHeader: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "dialog-header", className },
+      children,
+    ),
+  DialogTitle: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) =>
+    React.createElement(
+      "h2",
+      { "data-testid": "dialog-title", className },
+      children,
+    ),
+  DialogClose: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) =>
+    React.createElement(
+      "button",
+      { "data-testid": "dialog-close", className },
+      children,
+    ),
+}));
+
+jest.mock("next/link", () => ({
+  __esModule: true,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) =>
+    React.createElement("a", { href }, children),
+}));
+
+import MissionModal from "../MissionModal";
+
+describe("MissionModal", () => {
+  it("title and close button are rendered inside the same dialog-header container", () => {
+    const html = renderToStaticMarkup(React.createElement(MissionModal));
+    // Find the header block — everything between data-testid="dialog-header" open and next closing tag
+    const headerMatch = html.match(
+      /data-testid="dialog-header"[^>]*>([\s\S]*?)<\/div>/,
+    );
+    expect(headerMatch).not.toBeNull();
+    const headerContent = headerMatch![0];
+    expect(headerContent).toContain('data-testid="dialog-title"');
+    expect(headerContent).toContain('data-testid="dialog-close"');
+  });
+
+  it("the close button renders the × character", () => {
+    const html = renderToStaticMarkup(React.createElement(MissionModal));
+    // × is rendered as × or as the entity in attributes; in text content it stays as ×
+    expect(html).toContain("×");
+  });
+
+  it("the DialogContent className contains the Tailwind modifier to hide the default close button", () => {
+    const html = renderToStaticMarkup(React.createElement(MissionModal));
+    // renderToStaticMarkup HTML-encodes & in attributes: [&>...] becomes [&amp;>...]
+    expect(html).toContain("button.absolute]:hidden");
+  });
+});

--- a/src/components/ProductDetail/ProductDetailPanel.tsx
+++ b/src/components/ProductDetail/ProductDetailPanel.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { PriceTrend } from "@/components/PriceTrend";
+import { InstallmentBadge } from "@/components/InstallmentBadge";
+import { CompareTable } from "@/components/CompareTable";
+import { PriceHistoryChart } from "@/components/PriceHistory";
+import { matchOffers } from "@/features/price-search/match";
+import { fetchPriceHistory } from "@/features/price-history/history";
+import { useFollowedProduct } from "@/features/price-follow/useFollowedProduct";
+import { useProductsStore } from "@/store/productsStore";
+import { imageLoader } from "@/features/price-search/image-loader";
+import type { Product } from "@/types/product.d";
+import type {
+  PriceHistoryEntry,
+  TrendMap,
+} from "@/features/price-history/types";
+
+const fmtARS = (n: number) =>
+  n.toLocaleString("es-AR", { style: "currency", currency: "ARS" });
+
+export interface ProductDetailPanelProps {
+  product: Product;
+  onBack: () => void;
+  currentQuery: string;
+  trendMap?: TrendMap;
+  narrow?: boolean;
+}
+
+export function ProductDetailPanel({
+  product,
+  onBack,
+  currentQuery,
+  trendMap = {},
+  narrow = false,
+}: ProductDetailPanelProps) {
+  const allProducts = useProductsStore((s) => s.products);
+  const [priceHistory, setPriceHistory] = useState<PriceHistoryEntry[]>([]);
+  const { isFollowed, toggle } = useFollowedProduct(product.url);
+
+  useEffect(() => {
+    if (!currentQuery) return;
+    fetchPriceHistory(currentQuery)
+      .then(setPriceHistory)
+      .catch(() => {});
+  }, [currentQuery]);
+
+  const offers = matchOffers(product, allProducts);
+  const trend = product.url
+    ? (trendMap[product.url] ?? trendMap["__global__"])
+    : undefined;
+
+  return (
+    <div className="flex flex-col gap-6">
+      {/* Back navigation */}
+      <button
+        onClick={onBack}
+        className="self-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        ← Volver a resultados
+      </button>
+
+      {/* Hero grid */}
+      <div
+        className={
+          narrow
+            ? "grid grid-cols-1 gap-8"
+            : "grid grid-cols-1 gap-8 md:grid-cols-[minmax(0,420px)_1fr]"
+        }
+      >
+        {/* Image column */}
+        <div className="flex flex-col gap-3">
+          <div className="relative aspect-square overflow-hidden rounded-lg bg-muted">
+            <Image
+              loader={imageLoader}
+              src={product.image || "/placeholder.png"}
+              alt={product.name ?? "Producto"}
+              fill
+              sizes="420px"
+              className="object-contain p-4"
+            />
+          </div>
+          {/* Thumbnail row placeholders */}
+          <div className="flex gap-2">
+            {[0, 1, 2, 3].map((i) => (
+              <div key={i} className="h-16 w-16 shrink-0 rounded-md bg-muted" />
+            ))}
+          </div>
+        </div>
+
+        {/* Buy box column */}
+        <div className="flex flex-col gap-3">
+          {/* Store badge */}
+          <div className="flex items-center gap-2">
+            <Badge
+              variant="secondary"
+              className="rounded-full text-[11px] font-semibold"
+            >
+              {product.from}
+            </Badge>
+          </div>
+
+          {/* Brand */}
+          {product.brand && (
+            <p className="text-xs font-semibold uppercase tracking-[0.04em] text-muted-foreground">
+              {product.brand}
+            </p>
+          )}
+
+          {/* Name */}
+          {product.name && (
+            <h1 className="font-display text-3xl font-bold text-foreground">
+              {product.name}
+            </h1>
+          )}
+
+          {/* Price */}
+          {product.price != null && (
+            <p
+              className="font-display text-4xl font-bold"
+              style={{ color: "var(--price)" }}
+            >
+              {fmtARS(product.price)}
+            </p>
+          )}
+
+          {/* Trend + installment */}
+          <div className="flex flex-wrap items-center gap-2">
+            {trend && (
+              <PriceTrend
+                direction={trend.direction}
+                delta={trend.delta}
+                label="vs ayer"
+              />
+            )}
+            {product.installment != null && (
+              <InstallmentBadge installment={product.installment} />
+            )}
+          </div>
+
+          {/* Best price label */}
+          {offers.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              El mejor precio entre {offers.length} tienda
+              {offers.length !== 1 ? "s" : ""}
+            </p>
+          )}
+
+          <div className="h-px bg-border" />
+
+          {/* CTA buttons */}
+          <div className="flex gap-3">
+            <Button asChild className="flex-1 rounded-xl py-3">
+              <a href={product.url} target="_blank" rel="noopener noreferrer">
+                Ir a {product.from}
+              </a>
+            </Button>
+            <Button
+              variant={isFollowed ? "secondary" : "outline"}
+              className="rounded-xl px-4 py-3"
+              onClick={toggle}
+            >
+              {isFollowed ? "✓ Siguiendo" : "♡ Seguir precio"}
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {/* Compare section */}
+      <div className="flex flex-col gap-3">
+        <h2 className="text-lg font-bold text-foreground">
+          Comparar entre tiendas
+        </h2>
+        {offers.length > 0 ? (
+          <CompareTable
+            offers={offers}
+            onGoToStore={(url) => window.open(url, "_blank")}
+          />
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            No se encontraron otras tiendas con este producto.
+          </p>
+        )}
+      </div>
+
+      {/* Price history section */}
+      <div className="flex flex-col gap-3">
+        <h2 className="text-lg font-bold text-foreground">
+          Historial de precios
+        </h2>
+        <div className="rounded-lg border p-4">
+          <PriceHistoryChart data={priceHistory} />
+          {priceHistory.length < 2 && (
+            <p className="mt-2 text-xs text-muted-foreground">
+              No hay suficiente historial para mostrar el gráfico.
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProductDetail/__tests__/ProductDetailPanel.test.tsx
+++ b/src/components/ProductDetail/__tests__/ProductDetailPanel.test.tsx
@@ -77,7 +77,7 @@ jest.mock("@/features/price-search/match", () => ({
 }));
 
 import { useProductsStore } from "@/store/productsStore";
-const mockUseStore = useProductsStore as jest.Mock;
+const mockUseStore = useProductsStore as unknown as jest.Mock;
 
 import { ProductDetailPanel } from "../ProductDetailPanel";
 

--- a/src/components/ProductDetail/__tests__/ProductDetailPanel.test.tsx
+++ b/src/components/ProductDetail/__tests__/ProductDetailPanel.test.tsx
@@ -1,0 +1,157 @@
+/** @jest-environment node */
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+import { StoreNamesEnum } from "@/enums/stores.enum";
+import type { Product } from "@/types/product";
+
+jest.mock("@/store/productsStore", () => ({
+  useProductsStore: jest.fn(),
+}));
+
+jest.mock("@/features/price-follow/useFollowedProduct", () => ({
+  useFollowedProduct: () => ({ isFollowed: false, toggle: jest.fn() }),
+}));
+
+jest.mock("@/features/price-history/history", () => ({
+  fetchPriceHistory: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock("@/components/CompareTable", () => ({
+  CompareTable: ({ offers }: { offers: unknown[] }) =>
+    React.createElement(
+      "div",
+      { "data-testid": "compare-table" },
+      `${offers.length} offers`,
+    ),
+}));
+
+jest.mock("@/components/PriceHistory", () => ({
+  PriceHistoryChart: () =>
+    React.createElement("div", { "data-testid": "price-history-chart" }),
+}));
+
+jest.mock("@/components/PriceTrend", () => ({
+  PriceTrend: () =>
+    React.createElement("div", { "data-testid": "price-trend" }),
+}));
+
+jest.mock("@/components/InstallmentBadge", () => ({
+  InstallmentBadge: () =>
+    React.createElement("div", { "data-testid": "installment-badge" }),
+}));
+
+jest.mock("@/components/ui/button", () => ({
+  Button: ({
+    children,
+    onClick,
+    asChild,
+    className,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    asChild?: boolean;
+    className?: string;
+  }) => {
+    if (asChild && React.isValidElement(children)) {
+      return React.cloneElement(
+        children as React.ReactElement<{ className?: string }>,
+        { className },
+      );
+    }
+    return React.createElement("button", { onClick, className }, children);
+  },
+}));
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) =>
+    React.createElement("img", { src, alt }),
+}));
+
+jest.mock("@/features/price-search/image-loader", () => ({
+  imageLoader: ({ src }: { src: string }) => src,
+}));
+
+jest.mock("@/features/price-search/match", () => ({
+  matchOffers: jest.fn().mockReturnValue([]),
+}));
+
+import { useProductsStore } from "@/store/productsStore";
+const mockUseStore = useProductsStore as jest.Mock;
+
+import { ProductDetailPanel } from "../ProductDetailPanel";
+
+const mockProduct: Product = {
+  name: "Samsung Galaxy S24",
+  brand: "Samsung",
+  price: 1500000,
+  from: StoreNamesEnum.FRAVEGA,
+  image: "https://example.com/image.jpg",
+  url: "https://fravega.com/product/1",
+  installment: 12,
+};
+
+beforeEach(() => {
+  mockUseStore.mockImplementation(
+    (selector: (s: { products: Product[] }) => unknown) =>
+      selector({ products: [mockProduct] }),
+  );
+});
+
+describe("ProductDetailPanel", () => {
+  it("renders the product name", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProductDetailPanel, {
+        product: mockProduct,
+        onBack: jest.fn(),
+        currentQuery: "samsung",
+      }),
+    );
+    expect(html).toContain("Samsung Galaxy S24");
+  });
+
+  it("renders the formatted price", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProductDetailPanel, {
+        product: mockProduct,
+        onBack: jest.fn(),
+        currentQuery: "samsung",
+      }),
+    );
+    // Price 1500000 formatted as ARS
+    expect(html).toContain("1.500.000");
+  });
+
+  it("contains 'Volver a resultados' back button", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProductDetailPanel, {
+        product: mockProduct,
+        onBack: jest.fn(),
+        currentQuery: "samsung",
+      }),
+    );
+    expect(html).toContain("Volver a resultados");
+  });
+
+  it("contains 'Comparar entre tiendas' heading", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProductDetailPanel, {
+        product: mockProduct,
+        onBack: jest.fn(),
+        currentQuery: "samsung",
+      }),
+    );
+    expect(html).toContain("Comparar entre tiendas");
+  });
+
+  it("contains 'Historial de precios' heading", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(ProductDetailPanel, {
+        product: mockProduct,
+        onBack: jest.fn(),
+        currentQuery: "samsung",
+      }),
+    );
+    expect(html).toContain("Historial de precios");
+  });
+});

--- a/src/components/ProductList/ProductList.tsx
+++ b/src/components/ProductList/ProductList.tsx
@@ -10,9 +10,7 @@ import { ErrorAlert } from "@/components/ErrorAlert";
 import { fetchTrendMap } from "@/features/price-history/trend";
 import { PriceTrend } from "@/components/PriceTrend";
 import { InstallmentBadge } from "@/components/InstallmentBadge";
-import { ProductDetail } from "@/components/ProductDetail";
 import type { TrendMap } from "@/features/price-history/types";
-import type { Product } from "@/types/product.d";
 
 const ITEMS_PER_PAGE = 12;
 
@@ -46,8 +44,8 @@ export default function ProductList() {
   const [loadingMessage, setLoadingMessage] = useState("");
   const [currentPage, setCurrentPage] = useState(1);
   const [prevProductsRef, setPrevProductsRef] = useState(products);
+  const setSelectedProduct = useProductsStore((s) => s.setSelectedProduct);
   const [trendMap, setTrendMap] = useState<TrendMap>({});
-  const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
 
   if (prevProductsRef !== products) {
     setPrevProductsRef(products);
@@ -231,14 +229,6 @@ export default function ProductList() {
           </button>
         </div>
       )}
-
-      <ProductDetail
-        product={selectedProduct}
-        open={selectedProduct !== null}
-        onClose={() => setSelectedProduct(null)}
-        currentQuery={currentQuery}
-        trendMap={trendMap}
-      />
     </div>
   );
 }

--- a/src/components/ResultsOrchestrator/ResultsOrchestrator.tsx
+++ b/src/components/ResultsOrchestrator/ResultsOrchestrator.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { useProductsStore } from "@/store/productsStore";
+import { ProductDetailPanel } from "@/components/ProductDetail/ProductDetailPanel";
+import type { ReactNode } from "react";
+
+interface ResultsOrchestratorProps {
+  children: ReactNode;
+}
+
+export function ResultsOrchestrator({ children }: ResultsOrchestratorProps) {
+  const selectedProduct = useProductsStore((s) => s.selectedProduct);
+  const setSelectedProduct = useProductsStore((s) => s.setSelectedProduct);
+  const currentQuery = useProductsStore((s) => s.productSearched);
+
+  if (selectedProduct !== null) {
+    return (
+      <ProductDetailPanel
+        product={selectedProduct}
+        onBack={() => setSelectedProduct(null)}
+        currentQuery={currentQuery}
+      />
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/ResultsOrchestrator/__tests__/ResultsOrchestrator.test.tsx
+++ b/src/components/ResultsOrchestrator/__tests__/ResultsOrchestrator.test.tsx
@@ -35,7 +35,6 @@ const MOCK_PRODUCT = {
   from: "Fravega",
   brand: "Apple",
   image: "",
-  installment: null,
 };
 
 describe("ResultsOrchestrator", () => {

--- a/src/components/ResultsOrchestrator/__tests__/ResultsOrchestrator.test.tsx
+++ b/src/components/ResultsOrchestrator/__tests__/ResultsOrchestrator.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * @jest-environment node
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+
+const mockSetSelectedProduct = jest.fn();
+
+let mockSelectedProduct: import("@/types/product.d").Product | null = null;
+let mockProductSearched = "";
+
+jest.mock("@/store/productsStore", () => ({
+  useProductsStore: (selector: (s: unknown) => unknown) => {
+    const state = {
+      selectedProduct: mockSelectedProduct,
+      setSelectedProduct: mockSetSelectedProduct,
+      productSearched: mockProductSearched,
+      products: [],
+    };
+    return selector(state);
+  },
+}));
+
+jest.mock("@/components/ProductDetail/ProductDetailPanel", () => ({
+  ProductDetailPanel: ({ product }: { product: { name?: string } }) => (
+    <div data-testid="panel">{product.name}</div>
+  ),
+}));
+
+import { ResultsOrchestrator } from "../ResultsOrchestrator";
+
+const MOCK_PRODUCT = {
+  name: "iPhone 15",
+  price: 100000,
+  url: "https://example.com",
+  from: "Fravega",
+  brand: "Apple",
+  image: "",
+  installment: null,
+};
+
+describe("ResultsOrchestrator", () => {
+  beforeEach(() => {
+    mockSelectedProduct = null;
+    mockProductSearched = "";
+  });
+
+  it("renders children when selectedProduct is null", () => {
+    const html = renderToStaticMarkup(
+      <ResultsOrchestrator>
+        <div id="grid">grid</div>
+      </ResultsOrchestrator>,
+    );
+    expect(html).toContain("grid");
+    expect(html).not.toContain("panel");
+  });
+
+  it("renders ProductDetailPanel when selectedProduct is set", () => {
+    mockSelectedProduct = MOCK_PRODUCT as import("@/types/product.d").Product;
+    const html = renderToStaticMarkup(
+      <ResultsOrchestrator>
+        <div id="grid">grid</div>
+      </ResultsOrchestrator>,
+    );
+    expect(html).toContain("panel");
+    expect(html).toContain("iPhone 15");
+    expect(html).not.toContain("grid");
+  });
+});

--- a/src/features/price-follow/__tests__/useFollowedProduct.test.ts
+++ b/src/features/price-follow/__tests__/useFollowedProduct.test.ts
@@ -1,0 +1,70 @@
+/** @jest-environment node */
+import {
+  FOLLOW_KEY,
+  getFollowedUrls,
+  setFollowedUrls,
+} from "../useFollowedProduct";
+
+// We test the pure localStorage helpers directly since the hook uses useEffect
+// and is not renderable in node environment. The hook itself is tested via behavior.
+
+const mockStorage: Record<string, string> = {};
+
+beforeEach(() => {
+  Object.keys(mockStorage).forEach((k) => delete mockStorage[k]);
+});
+
+describe("getFollowedUrls", () => {
+  it("returns empty array when localStorage key is absent", () => {
+    const result = getFollowedUrls(mockStorage);
+    expect(result).toEqual([]);
+  });
+
+  it("returns parsed array when localStorage has URLs", () => {
+    mockStorage[FOLLOW_KEY] = JSON.stringify(["http://a.com", "http://b.com"]);
+    const result = getFollowedUrls(mockStorage);
+    expect(result).toHaveLength(2);
+    expect(result).toContain("http://a.com");
+    expect(result).toContain("http://b.com");
+  });
+
+  it("returns empty array when stored JSON is malformed", () => {
+    mockStorage[FOLLOW_KEY] = "not-valid-json";
+    const result = getFollowedUrls(mockStorage);
+    expect(result).toEqual([]);
+  });
+});
+
+describe("setFollowedUrls", () => {
+  it("serializes the array and writes it to storage", () => {
+    setFollowedUrls(mockStorage, ["http://x.com"]);
+    expect(mockStorage[FOLLOW_KEY]).toBe(JSON.stringify(["http://x.com"]));
+  });
+
+  it("overwrites previous value", () => {
+    mockStorage[FOLLOW_KEY] = JSON.stringify(["http://old.com"]);
+    setFollowedUrls(mockStorage, ["http://new.com"]);
+    expect(mockStorage[FOLLOW_KEY]).toBe(JSON.stringify(["http://new.com"]));
+  });
+});
+
+describe("follow toggle logic", () => {
+  it("adding a URL that is not present results in it being in the list", () => {
+    const urls: string[] = [];
+    const url = "http://product.com";
+    const next = urls.includes(url)
+      ? urls.filter((u) => u !== url)
+      : [...urls, url];
+    expect(next).toContain(url);
+  });
+
+  it("removing a URL that is present results in it being absent", () => {
+    const urls = ["http://product.com"];
+    const url = "http://product.com";
+    const next = urls.includes(url)
+      ? urls.filter((u) => u !== url)
+      : [...urls, url];
+    expect(next).not.toContain(url);
+    expect(next).toHaveLength(0);
+  });
+});

--- a/src/features/price-follow/useFollowedProduct.ts
+++ b/src/features/price-follow/useFollowedProduct.ts
@@ -1,0 +1,58 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+export const FOLLOW_KEY = "qdm:followed";
+
+// Pure helpers — exported for testing
+export function getFollowedUrls(storage: Record<string, string>): string[] {
+  try {
+    const raw = storage[FOLLOW_KEY];
+    if (!raw) return [];
+    return JSON.parse(raw) as string[];
+  } catch {
+    return [];
+  }
+}
+
+export function setFollowedUrls(
+  storage: Record<string, string>,
+  urls: string[],
+): void {
+  storage[FOLLOW_KEY] = JSON.stringify(urls);
+}
+
+function subscribe(callback: () => void): () => void {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
+export function useFollowedProduct(url: string | undefined): {
+  isFollowed: boolean;
+  toggle: () => void;
+} {
+  const isFollowed = useSyncExternalStore(
+    subscribe,
+    () =>
+      url
+        ? getFollowedUrls(
+            localStorage as unknown as Record<string, string>,
+          ).includes(url)
+        : false,
+    () => false,
+  );
+
+  const toggle = () => {
+    if (typeof window === "undefined" || !url) return;
+    const storage = localStorage as unknown as Record<string, string>;
+    const urls = getFollowedUrls(storage);
+    const next = urls.includes(url)
+      ? urls.filter((u) => u !== url)
+      : [...urls, url];
+    setFollowedUrls(storage, next);
+    window.dispatchEvent(new StorageEvent("storage", { key: FOLLOW_KEY }));
+  };
+
+  return { isFollowed, toggle };
+}

--- a/src/store/__tests__/productsStore.test.ts
+++ b/src/store/__tests__/productsStore.test.ts
@@ -1,4 +1,5 @@
 import { useProductsStore } from "../productsStore";
+import { selectPhase } from "../productsStore";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { ALL } from "@/features/price-search/constants";
 
@@ -9,8 +10,19 @@ jest.mock("@/features/price-search/api", () => ({
 import { getProduct } from "@/features/price-search/api";
 const mockGetProduct = getProduct as jest.Mock;
 
-const product = (name: string, brand: string, price: number, from: StoreNamesEnum) => ({
-  name, brand, price, from, image: "", url: "", installment: 0,
+const product = (
+  name: string,
+  brand: string,
+  price: number,
+  from: StoreNamesEnum,
+) => ({
+  name,
+  brand,
+  price,
+  from,
+  image: "",
+  url: "",
+  installment: 0,
 });
 
 beforeEach(() => {
@@ -23,6 +35,7 @@ beforeEach(() => {
     stores: [],
     isLoading: false,
     error: null,
+    selectedProduct: null,
   });
   jest.clearAllMocks();
 });
@@ -62,13 +75,17 @@ describe("useProductsStore", () => {
 
   it("toggleStore agrega una tienda a selectedStores", () => {
     useProductsStore.getState().toggleStore(StoreNamesEnum.FRAVEGA);
-    expect(useProductsStore.getState().selectedStores).toContain(StoreNamesEnum.FRAVEGA);
+    expect(useProductsStore.getState().selectedStores).toContain(
+      StoreNamesEnum.FRAVEGA,
+    );
   });
 
   it("toggleStore quita una tienda ya seleccionada", () => {
     useProductsStore.setState({ selectedStores: [StoreNamesEnum.FRAVEGA] });
     useProductsStore.getState().toggleStore(StoreNamesEnum.FRAVEGA);
-    expect(useProductsStore.getState().selectedStores).not.toContain(StoreNamesEnum.FRAVEGA);
+    expect(useProductsStore.getState().selectedStores).not.toContain(
+      StoreNamesEnum.FRAVEGA,
+    );
   });
 
   it("toggleStore puede seleccionar múltiples tiendas", () => {
@@ -140,7 +157,9 @@ describe("useProductsStore — estado de error", () => {
 
     await useProductsStore.getState().getProducts("tv");
 
-    expect(useProductsStore.getState().error).toBe("No se pudo conectar. Verificá tu conexión e intentá de nuevo.");
+    expect(useProductsStore.getState().error).toBe(
+      "No se pudo conectar. Verificá tu conexión e intentá de nuevo.",
+    );
     expect(useProductsStore.getState().isLoading).toBe(false);
   });
 
@@ -151,5 +170,71 @@ describe("useProductsStore — estado de error", () => {
 
     expect(useProductsStore.getState().error).not.toBeNull();
     expect(useProductsStore.getState().isLoading).toBe(false);
+  });
+});
+
+describe("useProductsStore — selectedProduct", () => {
+  it("selectedProduct initializes as null", () => {
+    expect(useProductsStore.getState().selectedProduct).toBeNull();
+  });
+
+  it("setSelectedProduct updates the store with the given product", () => {
+    const p = {
+      name: "TV",
+      brand: "LG",
+      price: 100,
+      from: StoreNamesEnum.FRAVEGA,
+      image: "",
+      url: "http://x",
+      installment: 0,
+    };
+    useProductsStore.getState().setSelectedProduct(p);
+    expect(useProductsStore.getState().selectedProduct).toBe(p);
+  });
+
+  it("setSelectedProduct(null) clears selectedProduct", () => {
+    const p = {
+      name: "TV",
+      brand: "LG",
+      price: 100,
+      from: StoreNamesEnum.FRAVEGA,
+      image: "",
+      url: "http://x",
+      installment: 0,
+    };
+    useProductsStore.setState({ selectedProduct: p });
+    useProductsStore.getState().setSelectedProduct(null);
+    expect(useProductsStore.getState().selectedProduct).toBeNull();
+  });
+});
+
+describe("selectPhase", () => {
+  it("returns 'landing' when productSearched is empty, products empty, not loading", () => {
+    const state = useProductsStore.getState();
+    expect(selectPhase(state)).toBe("landing");
+  });
+
+  it("returns 'results' when productSearched is non-empty", () => {
+    useProductsStore.setState({ productSearched: "celular" });
+    expect(selectPhase(useProductsStore.getState())).toBe("results");
+  });
+
+  it("returns 'results' when products array is non-empty", () => {
+    const p = {
+      name: "TV",
+      brand: "LG",
+      price: 100,
+      from: StoreNamesEnum.FRAVEGA,
+      image: "",
+      url: "",
+      installment: 0,
+    };
+    useProductsStore.setState({ products: [p] });
+    expect(selectPhase(useProductsStore.getState())).toBe("results");
+  });
+
+  it("returns 'results' when isLoading is true", () => {
+    useProductsStore.setState({ isLoading: true });
+    expect(selectPhase(useProductsStore.getState())).toBe("results");
   });
 });

--- a/src/store/productsStore.ts
+++ b/src/store/productsStore.ts
@@ -6,7 +6,21 @@ import { capitalize } from "@/lib/capitalize";
 import { Product } from "@/types/product";
 import { create } from "zustand";
 
-type SortBy = "price_asc" | "price_desc" | "installments_desc" | "best_installment";
+export type AppPhase = "landing" | "results";
+
+export function selectPhase(
+  s: Pick<State, "productSearched" | "products" | "isLoading">,
+): AppPhase {
+  return s.productSearched === "" && s.products.length === 0 && !s.isLoading
+    ? "landing"
+    : "results";
+}
+
+type SortBy =
+  | "price_asc"
+  | "price_desc"
+  | "installments_desc"
+  | "best_installment";
 
 interface State {
   getProducts: (productName: string) => Promise<void>;
@@ -33,6 +47,8 @@ interface State {
   setSortBy: (v: SortBy) => void;
   clearFilters: () => void;
   filteredProducts: () => Product[];
+  selectedProduct: Product | null;
+  setSelectedProduct: (product: Product | null) => void;
 }
 
 export const useProductsStore = create<State>((set, get) => ({
@@ -56,7 +72,7 @@ export const useProductsStore = create<State>((set, get) => ({
       });
 
       const brands = productsUpdated.map((product: Product) =>
-        capitalize(product.brand)
+        capitalize(product.brand),
       );
       const uniqueBrands = Array.from(new Set(brands));
       uniqueBrands.sort((a, b) => a.localeCompare(b));
@@ -104,26 +120,50 @@ export const useProductsStore = create<State>((set, get) => ({
   setSelectedCSI: (v) => set({ selectedCSI: v }),
   setSortBy: (v) => set({ sortBy: v }),
   clearFilters: () =>
-    set({ priceMin: null, priceMax: null, selectedCSI: null, sortBy: "price_asc", error: null, selectedStores: [] }),
+    set({
+      priceMin: null,
+      priceMax: null,
+      selectedCSI: null,
+      sortBy: "price_asc",
+      error: null,
+      selectedStores: [],
+    }),
+  selectedProduct: null,
+  setSelectedProduct: (product) => set({ selectedProduct: product }),
   filteredProducts: () => {
-    const { products, selectedBrand, selectedStores, priceMin, priceMax, selectedCSI, sortBy } = get();
+    const {
+      products,
+      selectedBrand,
+      selectedStores,
+      priceMin,
+      priceMax,
+      selectedCSI,
+      sortBy,
+    } = get();
 
     let result = products.filter((p) => {
-      if (selectedBrand !== ALL && capitalize(p.brand) !== selectedBrand) return false;
-      if (selectedStores.length > 0 && !selectedStores.includes(p.from)) return false;
+      if (selectedBrand !== ALL && capitalize(p.brand) !== selectedBrand)
+        return false;
+      if (selectedStores.length > 0 && !selectedStores.includes(p.from))
+        return false;
       if (priceMin !== null && (p.price ?? 0) < priceMin) return false;
       if (priceMax !== null && (p.price ?? 0) > priceMax) return false;
-      if (selectedCSI !== null && (p.installment ?? 0) !== selectedCSI) return false;
+      if (selectedCSI !== null && (p.installment ?? 0) !== selectedCSI)
+        return false;
       return true;
     });
 
     result = [...result].sort((a, b) => {
-      if (sortBy === "price_asc") return (a.price ?? Infinity) - (b.price ?? Infinity);
+      if (sortBy === "price_asc")
+        return (a.price ?? Infinity) - (b.price ?? Infinity);
       if (sortBy === "price_desc") return (b.price ?? 0) - (a.price ?? 0);
-      if (sortBy === "installments_desc") return (b.installment ?? 0) - (a.installment ?? 0);
+      if (sortBy === "installments_desc")
+        return (b.installment ?? 0) - (a.installment ?? 0);
       if (sortBy === "best_installment") {
-        const aVal = (a.installment ?? 0) > 0 ? (a.price ?? 0) / a.installment! : Infinity;
-        const bVal = (b.installment ?? 0) > 0 ? (b.price ?? 0) / b.installment! : Infinity;
+        const aVal =
+          (a.installment ?? 0) > 0 ? (a.price ?? 0) / a.installment! : Infinity;
+        const bVal =
+          (b.installment ?? 0) > 0 ? (b.price ?? 0) / b.installment! : Infinity;
         return aVal - bVal;
       }
       return 0;


### PR DESCRIPTION
## Summary

- **CategoryChips**: 8 category quick-search chips on landing (self-gates when search is active)
- **Disclaimer phase gate**: `<Disclaimer>` returns null before first search (`productSearched === ""`)
- **MissionModal**: close button (`×`) now inline with title in the same flex row (28×28px)
- **Zustand store**: added `selectedProduct`, `setSelectedProduct`, `selectPhase` selector
- **ProductDetailPanel**: new inline 2-col layout (image | buy box) replacing the Sheet; includes `PriceTrend`, `InstallmentBadge`, `CompareTable`, `PriceHistoryChart`, and "Seguir precio" toggle
- **ResultsOrchestrator**: client boundary — swaps grid ↔ `ProductDetailPanel` based on `selectedProduct`
- **ProductList**: removes local `selectedProduct` state and Sheet, delegates to store
- **useFollowedProduct**: localStorage follow toggle using `useSyncExternalStore` (SSR-safe, no setState-in-effect lint violation)

## Test plan

- [x] 224 tests passing (`npm test`)
- [x] 0 lint errors (`npm run lint`)
- [ ] Verify CategoryChips appear on landing and disappear after search
- [ ] Verify Disclaimer is hidden on landing, shows after search
- [ ] Verify clicking a product card opens inline ProductDetailPanel
- [ ] Verify "← Volver a resultados" returns to grid
- [ ] Verify "Seguir precio" toggle persists in localStorage
- [ ] Verify MissionModal × button is inline with the title