### PR TITLE
test(e2e): update product-detail specs and add category-chips/disclaimer flows

### DIFF
--- a/e2e/category-chips.spec.ts
+++ b/e2e/category-chips.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from "@playwright/test";
+import { buildProducts } from "./fixtures/products";
+import { gotoAndWaitReady, mockScrapeApi } from "./helpers/setup";
+
+const CHIP_LABELS = [
+  "Celulares",
+  "Tablets",
+  "TVs",
+  "Auriculares",
+  "Notebooks",
+  "Consolas",
+  "Heladeras",
+  "Lavadoras",
+];
+
+test.describe("CategoryChips", () => {
+  test("chips are visible on landing before any search", async ({ page }) => {
+    await mockScrapeApi(page, []);
+    await gotoAndWaitReady(page);
+
+    for (const label of CHIP_LABELS) {
+      await expect(
+        page.getByRole("button", { name: label, exact: true }),
+      ).toBeVisible();
+    }
+  });
+
+  test("chips are hidden after a search is submitted", async ({ page }) => {
+    await mockScrapeApi(page, buildProducts(3));
+    await gotoAndWaitReady(page);
+
+    // Confirm chips visible before search
+    await expect(
+      page.getByRole("button", { name: "Celulares", exact: true }),
+    ).toBeVisible();
+
+    // Submit a search via the form
+    const searchInput = page.getByPlaceholder("Nombre del producto...");
+    const searchButton = page.getByRole("button", { name: /buscar/i });
+    await searchInput.fill("celular");
+    await Promise.all([
+      page.waitForResponse((resp) => resp.url().includes("/api/scrape")),
+      searchButton.click(),
+    ]);
+
+    // Chips must be gone after search
+    await expect(
+      page.getByRole("button", { name: "Celulares", exact: true }),
+    ).toHaveCount(0);
+  });
+
+  test("clicking a chip triggers a product search", async ({ page }) => {
+    await mockScrapeApi(page, buildProducts(3));
+    await gotoAndWaitReady(page);
+
+    const [response] = await Promise.all([
+      page.waitForResponse((resp) => resp.url().includes("/api/scrape")),
+      page.getByRole("button", { name: "Celulares", exact: true }).click(),
+    ]);
+
+    expect(response.status()).toBe(200);
+
+    // Product cards should appear
+    await expect(page.getByTestId("product-card")).toHaveCount(3);
+  });
+});

--- a/e2e/disclaimer.spec.ts
+++ b/e2e/disclaimer.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect } from "@playwright/test";
+import { buildProducts } from "./fixtures/products";
+import {
+  gotoAndWaitReady,
+  mockScrapeApi,
+  submitSearchAndWait,
+} from "./helpers/setup";
+
+test.describe("Disclaimer", () => {
+  test("disclaimer is not visible on landing before any search", async ({
+    page,
+  }) => {
+    await mockScrapeApi(page, []);
+    await gotoAndWaitReady(page);
+
+    // The disclaimer heading should not be in the DOM while in landing phase
+    await expect(page.getByText("¿Cómo funciona?")).toHaveCount(0);
+  });
+
+  test("disclaimer is visible after a search is submitted", async ({
+    page,
+  }) => {
+    await mockScrapeApi(page, buildProducts(3));
+    await gotoAndWaitReady(page);
+
+    await submitSearchAndWait(page, "celular");
+
+    await expect(page.getByText("¿Cómo funciona?")).toBeVisible();
+  });
+
+  test("dismissing the disclaimer hides it for the rest of the session", async ({
+    page,
+  }) => {
+    await mockScrapeApi(page, buildProducts(3));
+    await gotoAndWaitReady(page);
+
+    await submitSearchAndWait(page, "celular");
+    await expect(page.getByText("¿Cómo funciona?")).toBeVisible();
+
+    // Dismiss
+    await page.getByRole("button", { name: /Cerrar aviso/i }).click();
+    await expect(page.getByText("¿Cómo funciona?")).toHaveCount(0);
+
+    // Run a second search — disclaimer must stay hidden (session close state)
+    await mockScrapeApi(page, buildProducts(2));
+    await submitSearchAndWait(page, "tv");
+    await expect(page.getByText("¿Cómo funciona?")).toHaveCount(0);
+  });
+});

--- a/e2e/happy-path.spec.ts
+++ b/e2e/happy-path.spec.ts
@@ -44,9 +44,11 @@ test.describe("SPEC-42: flujo completo desktop", () => {
     await sel.paginationNext.click();
     await expect(sel.productCards).toHaveCount(3);
 
-    // 6. Click a product card (should open external link)
-    const firstCard = sel.productCards.first();
-    await expect(firstCard).toBeVisible();
+    // 6. Click a product card → opens inline detail panel
+    await sel.productCards.first().click();
+    await expect(
+      page.getByRole("button", { name: /Volver a resultados/i }),
+    ).toBeVisible();
   });
 });
 

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -27,5 +27,24 @@ export function getSelectors(page: Page) {
     filterPanelToggle: page.getByRole("button", { name: /filtros/i }),
     activeFiltersCount: page.getByTestId("active-filters-count"),
     clearFiltersButton: page.getByRole("button", { name: /limpiar/i }),
+
+    // ProductDetailPanel selectors
+    backButton: page.getByRole("button", { name: /Volver a resultados/i }),
+    detailPanel: page.getByText("Volver a resultados").first(),
+    goToStoreLink: page.getByRole("link", { name: /Ir a/i }).first(),
+    followButton: page.getByRole("button", {
+      name: /Seguir precio|Siguiendo/i,
+    }),
+
+    // CategoryChips selectors
+    categoryChip: (label: string) =>
+      page.getByRole("button", { name: label, exact: true }),
+    categoryChips: page.getByRole("button", {
+      name: /Celulares|Tablets|TVs|Auriculares|Notebooks|Consolas|Heladeras|Lavadoras/i,
+    }),
+
+    // Disclaimer selectors
+    disclaimerHeading: page.getByText("¿Cómo funciona?"),
+    disclaimerDismiss: page.getByRole("button", { name: /Cerrar aviso/i }),
   };
 }

--- a/e2e/product-detail.spec.ts
+++ b/e2e/product-detail.spec.ts
@@ -8,12 +8,12 @@ import {
 } from "./helpers/setup";
 import { getSelectors } from "./helpers/selectors";
 
-test.describe("ProductDetail Sheet", () => {
+test.describe("ProductDetail inline panel", () => {
   test.beforeEach(async ({ page }) => {
     const products = buildProducts(3, { from: StoreNamesEnum.FRAVEGA });
     await mockScrapeApi(page, products);
 
-    // Mock price history API to return empty (avoid network calls in tests)
+    // Avoid real network calls for price history
     await page.route("**/api/prices/history**", (route) => {
       route.fulfill({
         status: 200,
@@ -26,48 +26,95 @@ test.describe("ProductDetail Sheet", () => {
     await submitSearchAndWait(page, "celular");
   });
 
-  test("card click opens Sheet without URL change", async ({ page }) => {
+  test("card click opens inline panel without a dialog and without URL change", async ({
+    page,
+  }) => {
     const sel = getSelectors(page);
     const initialUrl = page.url();
 
     await expect(sel.productCards).toHaveCount(3);
 
-    // Click first product card
     await sel.productCards.first().click();
 
-    // Sheet should be open (SheetContent renders in a portal with role="dialog")
-    await expect(page.getByRole("dialog")).toBeVisible();
+    // Panel is inline — "Volver a resultados" button is the landmark
+    await expect(sel.backButton).toBeVisible();
 
-    // URL should not have changed
+    // No Sheet/dialog overlay should be open
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+
+    // URL must not change
     expect(page.url()).toBe(initialUrl);
   });
 
-  test('"Ir a tienda" button opens a new tab', async ({ page, context }) => {
+  test('"Volver a resultados" closes the panel and restores the product grid', async ({
+    page,
+  }) => {
     const sel = getSelectors(page);
 
     await sel.productCards.first().click();
-    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(sel.backButton).toBeVisible();
 
-    // "Ir a [store]" opens a new tab via window.open(_blank)
+    await sel.backButton.click();
+
+    // Product cards should reappear
+    await expect(sel.productCards).toHaveCount(3);
+
+    // Back button must be gone
+    await expect(sel.backButton).toHaveCount(0);
+  });
+
+  test("panel renders expected section headings", async ({ page }) => {
+    const sel = getSelectors(page);
+
+    await sel.productCards.first().click();
+    await expect(sel.backButton).toBeVisible();
+
+    await expect(page.getByText("Comparar entre tiendas")).toBeVisible();
+    await expect(page.getByText("Historial de precios")).toBeVisible();
+
+    // Product name from the fixture ("Product 0")
+    await expect(page.getByText(/Product \d/)).toBeVisible();
+  });
+
+  test('"Ir a [store]" opens a new tab', async ({ page, context }) => {
+    const sel = getSelectors(page);
+
+    await sel.productCards.first().click();
+    await expect(sel.backButton).toBeVisible();
+
+    // "Ir a FRAVEGA" is an <a target="_blank"> (Button asChild)
     const [newPage] = await Promise.all([
       context.waitForEvent("page"),
-      page.getByRole("button", { name: /Ir a/i }).first().click(),
+      sel.goToStoreLink.click(),
     ]);
 
     await newPage.waitForLoadState("domcontentloaded");
     expect(newPage.url()).toContain("example.com");
   });
 
-  test("close button closes the Sheet", async ({ page }) => {
+  test('"Seguir precio" toggle switches label between followed and unfollowed states', async ({
+    page,
+  }) => {
     const sel = getSelectors(page);
 
     await sel.productCards.first().click();
-    const dialog = page.getByRole("dialog");
-    await expect(dialog).toBeVisible();
+    await expect(sel.backButton).toBeVisible();
 
-    // Click the close button (Cross2Icon button with sr-only "Close" text)
-    await page.getByRole("button", { name: /close/i }).click();
+    // Initial state: not following
+    await expect(
+      page.getByRole("button", { name: "♡ Seguir precio" }),
+    ).toBeVisible();
 
-    await expect(dialog).toBeHidden();
+    // Follow
+    await sel.followButton.click();
+    await expect(
+      page.getByRole("button", { name: "✓ Siguiendo" }),
+    ).toBeVisible();
+
+    // Unfollow
+    await page.getByRole("button", { name: "✓ Siguiendo" }).click();
+    await expect(
+      page.getByRole("button", { name: "♡ Seguir precio" }),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

- Rewrites `product-detail.spec.ts` for the new inline `ProductDetailPanel` (no Sheet/dialog)
- Updates `happy-path.spec.ts` step 6 to assert panel opens on card click
- Adds `category-chips.spec.ts` — chips visible on landing, hidden post-search, click triggers search
- Adds `disclaimer.spec.ts` — hidden on landing, visible post-search, dismiss works

## Test plan

- [ ] `npm run test:e2e` — all suites green with dev server running
- [ ] Verify: card click → "Volver a resultados" visible, no dialog
- [ ] Verify: "Seguir precio" toggle persists in localStorage
- [ ] Verify: CategoryChips disappear after first search