### PR TITLE
fix: export ProductDetailPanel from barrel and add computeToggle with full toggle tests

### DIFF
--- a/src/components/ProductDetail/index.ts
+++ b/src/components/ProductDetail/index.ts
@@ -1,1 +1,2 @@
 export { ProductDetail } from "./ProductDetail";
+export { ProductDetailPanel } from "./ProductDetailPanel";

--- a/src/features/price-follow/__tests__/useFollowedProduct.test.ts
+++ b/src/features/price-follow/__tests__/useFollowedProduct.test.ts
@@ -3,10 +3,8 @@ import {
   FOLLOW_KEY,
   getFollowedUrls,
   setFollowedUrls,
+  computeToggle,
 } from "../useFollowedProduct";
-
-// We test the pure localStorage helpers directly since the hook uses useEffect
-// and is not renderable in node environment. The hook itself is tested via behavior.
 
 const mockStorage: Record<string, string> = {};
 
@@ -15,28 +13,26 @@ beforeEach(() => {
 });
 
 describe("getFollowedUrls", () => {
-  it("returns empty array when localStorage key is absent", () => {
-    const result = getFollowedUrls(mockStorage);
-    expect(result).toEqual([]);
+  it("returns empty array when key is absent", () => {
+    expect(getFollowedUrls(mockStorage)).toEqual([]);
   });
 
-  it("returns parsed array when localStorage has URLs", () => {
+  it("returns parsed array when key exists", () => {
     mockStorage[FOLLOW_KEY] = JSON.stringify(["http://a.com", "http://b.com"]);
-    const result = getFollowedUrls(mockStorage);
-    expect(result).toHaveLength(2);
-    expect(result).toContain("http://a.com");
-    expect(result).toContain("http://b.com");
+    expect(getFollowedUrls(mockStorage)).toEqual([
+      "http://a.com",
+      "http://b.com",
+    ]);
   });
 
-  it("returns empty array when stored JSON is malformed", () => {
+  it("returns empty array on malformed JSON", () => {
     mockStorage[FOLLOW_KEY] = "not-valid-json";
-    const result = getFollowedUrls(mockStorage);
-    expect(result).toEqual([]);
+    expect(getFollowedUrls(mockStorage)).toEqual([]);
   });
 });
 
 describe("setFollowedUrls", () => {
-  it("serializes the array and writes it to storage", () => {
+  it("serializes and writes the array", () => {
     setFollowedUrls(mockStorage, ["http://x.com"]);
     expect(mockStorage[FOLLOW_KEY]).toBe(JSON.stringify(["http://x.com"]));
   });
@@ -48,23 +44,76 @@ describe("setFollowedUrls", () => {
   });
 });
 
-describe("follow toggle logic", () => {
-  it("adding a URL that is not present results in it being in the list", () => {
-    const urls: string[] = [];
-    const url = "http://product.com";
-    const next = urls.includes(url)
-      ? urls.filter((u) => u !== url)
-      : [...urls, url];
-    expect(next).toContain(url);
+describe("computeToggle", () => {
+  it("adds URL when not present", () => {
+    expect(computeToggle([], "http://a.com")).toEqual(["http://a.com"]);
   });
 
-  it("removing a URL that is present results in it being absent", () => {
-    const urls = ["http://product.com"];
-    const url = "http://product.com";
-    const next = urls.includes(url)
-      ? urls.filter((u) => u !== url)
-      : [...urls, url];
-    expect(next).not.toContain(url);
-    expect(next).toHaveLength(0);
+  it("removes URL when already present", () => {
+    expect(computeToggle(["http://a.com"], "http://a.com")).toEqual([]);
+  });
+
+  it("preserves other URLs when removing one", () => {
+    const result = computeToggle(
+      ["http://a.com", "http://b.com"],
+      "http://a.com",
+    );
+    expect(result).toEqual(["http://b.com"]);
+  });
+
+  it("adds without affecting other URLs", () => {
+    const result = computeToggle(["http://a.com"], "http://b.com");
+    expect(result).toEqual(["http://a.com", "http://b.com"]);
+  });
+});
+
+describe("full toggle flow (read → compute → write)", () => {
+  const URL = "http://product.com/p1";
+
+  it("follow: URL is absent → gets added to storage", () => {
+    const before = getFollowedUrls(mockStorage);
+    const next = computeToggle(before, URL);
+    setFollowedUrls(mockStorage, next);
+
+    expect(getFollowedUrls(mockStorage)).toContain(URL);
+  });
+
+  it("unfollow: URL is present → gets removed from storage", () => {
+    setFollowedUrls(mockStorage, [URL]);
+
+    const before = getFollowedUrls(mockStorage);
+    const next = computeToggle(before, URL);
+    setFollowedUrls(mockStorage, next);
+
+    expect(getFollowedUrls(mockStorage)).not.toContain(URL);
+    expect(getFollowedUrls(mockStorage)).toHaveLength(0);
+  });
+
+  it("double-toggle restores original state", () => {
+    const after1 = computeToggle(getFollowedUrls(mockStorage), URL);
+    setFollowedUrls(mockStorage, after1);
+    expect(getFollowedUrls(mockStorage)).toContain(URL);
+
+    const after2 = computeToggle(getFollowedUrls(mockStorage), URL);
+    setFollowedUrls(mockStorage, after2);
+    expect(getFollowedUrls(mockStorage)).not.toContain(URL);
+  });
+
+  it("multiple products can be followed independently", () => {
+    const URL2 = "http://product.com/p2";
+
+    setFollowedUrls(
+      mockStorage,
+      computeToggle(getFollowedUrls(mockStorage), URL),
+    );
+    setFollowedUrls(
+      mockStorage,
+      computeToggle(getFollowedUrls(mockStorage), URL2),
+    );
+
+    const followed = getFollowedUrls(mockStorage);
+    expect(followed).toContain(URL);
+    expect(followed).toContain(URL2);
+    expect(followed).toHaveLength(2);
   });
 });

--- a/src/features/price-follow/useFollowedProduct.ts
+++ b/src/features/price-follow/useFollowedProduct.ts
@@ -22,6 +22,12 @@ export function setFollowedUrls(
   storage[FOLLOW_KEY] = JSON.stringify(urls);
 }
 
+export function computeToggle(current: string[], url: string): string[] {
+  return current.includes(url)
+    ? current.filter((u) => u !== url)
+    : [...current, url];
+}
+
 function subscribe(callback: () => void): () => void {
   if (typeof window === "undefined") return () => {};
   window.addEventListener("storage", callback);
@@ -46,10 +52,7 @@ export function useFollowedProduct(url: string | undefined): {
   const toggle = () => {
     if (typeof window === "undefined" || !url) return;
     const storage = localStorage as unknown as Record<string, string>;
-    const urls = getFollowedUrls(storage);
-    const next = urls.includes(url)
-      ? urls.filter((u) => u !== url)
-      : [...urls, url];
+    const next = computeToggle(getFollowedUrls(storage), url);
     setFollowedUrls(storage, next);
     window.dispatchEvent(new StorageEvent("storage", { key: FOLLOW_KEY }));
   };


### PR DESCRIPTION
## Summary

- `src/components/ProductDetail/index.ts` — exports `ProductDetailPanel` from the barrel
- `useFollowedProduct.ts` — extracts `computeToggle(current, url)` as a pure exported function; hook uses it internally
- `useFollowedProduct.test.ts` — replaces inline reimplementation with real function calls; adds full toggle flow tests (follow, unfollow, double-toggle, multi-product)

## Test plan

- [x] 230 tests passing (`npm test`)
- [x] 0 lint errors (`npm run lint`)