### PR TITLE
feat(backend): price-alerts API, Supabase repository, HMAC token, and email helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,61 +1,26 @@
-﻿# ============================================================
-# quiendamenos — Variables de entorno
-# Copiá este archivo como .env.local y completá los valores.
-# ============================================================
+﻿# Redis — required for caching
+REDIS_URL=127.0.0.1
+REDIS_PORT=6379
+REDIS_PASSWORD=
 
-
-# ── Redis (Upstash) ─────────────────────────────────────────
-# Requerido en producción. En desarrollo se puede omitir
-# (el cache queda deshabilitado y cada request scrape directo).
-# Origen: Upstash Console → tu database → REST API
-UPSTASH_REDIS_REST_URL=https://xxx.upstash.io
-UPSTASH_REDIS_REST_TOKEN=
-
-
-# ── Supabase (historial de precios) ─────────────────────────
-# Opcional — si no está configurado, el historial de precios
-# se deshabilita silenciosamente sin afectar el scraping.
-#
-# SUPABASE_URL: URL REST del proyecto (NO el pooler Postgres).
-# Origen: Supabase Dashboard → Settings → API → Project URL
-# Formato: https://[ref].supabase.co
-SUPABASE_URL=https://wjirvlpwbslcxbnokhln.supabase.co
-
-# SUPABASE_SERVICE_ROLE_KEY: clave de servicio para inserts server-side.
-# NUNCA exponerla al browser (no usar NEXT_PUBLIC_).
-# Origen: Supabase Dashboard → Settings → API → service_role (secret)
-SUPABASE_SERVICE_ROLE_KEY=
-
-
-# ── Auth / Seguridad ─────────────────────────────────────────
-# Solo requeridos en producción. En desarrollo se omiten
-# y el middleware saltea la autenticación.
-#
-# API_SECRET_KEY: enviado en header x-api-key por el cliente.
-# Origen: generá un string aleatorio (ej. openssl rand -hex 32)
+# API authentication — required in production only
 API_SECRET_KEY=
 
-# CRON_SECRET: Bearer token para proteger /api/health-check.
-# Origen: configuralo en Vercel → Settings → Cron Jobs.
+# Supabase — required for price history and price alerts
+SUPABASE_URL=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# Price alerts — HMAC token signing (server only, never expose to client)
+# Generate with: openssl rand -hex 32
+ALERT_TOKEN_SECRET=
+
+# Resend — transactional email for price-drop notifications (server only)
+RESEND_API_KEY=
+
+# Cron secret — Bearer token for /api/cron/check-prices (server only)
+# Generate with: openssl rand -hex 32
 CRON_SECRET=
 
+# Base URL — used for building unsubscribe links in notification emails
+NEXT_PUBLIC_BASE_URL=https://quiendamenos.vercel.app
 
-# ── Email (alertas de scrapers) ──────────────────────────────
-# Opcional — si no está configurado, las alertas por email
-# se deshabilitan (el health-check sigue funcionando).
-# Origen: Resend Dashboard → API Keys (resend.com)
-RESEND_API_KEY=
-ALERT_EMAIL=tu@email.com
-
-
-# ── Scrapers ─────────────────────────────────────────────────
-# Opcional — usado por el scraper de Fravega como fallback
-# cuando la ruta pública devuelve 403 desde IPs de datacenter.
-# Origen: proveedor de scraping proxy (ej. ScraperAPI)
-SCRAPER_API_KEY=
-
-
-# ── Vercel (auto-inyectado) ───────────────────────────────────
-# Vercel inyecta esta variable automáticamente en deployments.
-# No la configures manualmente — solo es informativa.
-# VERCEL_PROJECT_PRODUCTION_URL=quiendamenos.vercel.app

--- a/src/app/api/price-alerts/__tests__/route.test.ts
+++ b/src/app/api/price-alerts/__tests__/route.test.ts
@@ -1,0 +1,167 @@
+/** @jest-environment node */
+import { POST } from "../route";
+import { NextRequest } from "next/server";
+
+jest.mock("@/platform/supabase", () => ({
+  getSupabaseClient: jest.fn(),
+}));
+
+import { getSupabaseClient } from "@/platform/supabase";
+const mockGetClient = getSupabaseClient as jest.Mock;
+
+function makeRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/price-alerts", {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeSupabaseMock({
+  countData = 0,
+  countError = null,
+  upsertError = null,
+}: {
+  countData?: number;
+  countError?: unknown;
+  upsertError?: unknown;
+} = {}) {
+  const selectFn = jest.fn().mockReturnThis();
+  const eqFn = jest.fn().mockReturnThis();
+  const isNullFn = jest.fn().mockReturnThis();
+  const limitFn = jest.fn().mockReturnThis();
+  const singleFn = jest.fn().mockResolvedValue({
+    data: { count: countData },
+    error: countError,
+  });
+
+  const onConflictFn = jest.fn().mockResolvedValue({ error: upsertError });
+
+  const fromFn = jest.fn((table: string) => {
+    if (table === "price_alerts") {
+      return {
+        select: selectFn,
+        eq: eqFn,
+        is: isNullFn,
+        limit: limitFn,
+        single: singleFn,
+        upsert: jest.fn().mockReturnValue({ onConflict: onConflictFn }),
+      };
+    }
+    return {};
+  });
+
+  return { from: fromFn };
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("POST /api/price-alerts", () => {
+  it("returns 503 when Supabase client is null", async () => {
+    mockGetClient.mockReturnValue(null);
+    const req = makeRequest({
+      email: "user@example.com",
+      productUrl: "https://store.com/p/1",
+      productName: "iPhone",
+      currentPrice: 100000,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 400 when email is missing", async () => {
+    mockGetClient.mockReturnValue(makeSupabaseMock());
+    const req = makeRequest({
+      productUrl: "https://store.com/p/1",
+      productName: "iPhone",
+      currentPrice: 100000,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/email/i);
+  });
+
+  it("returns 400 when email format is invalid", async () => {
+    mockGetClient.mockReturnValue(makeSupabaseMock());
+    const req = makeRequest({
+      email: "not-an-email",
+      productUrl: "https://store.com/p/1",
+      productName: "iPhone",
+      currentPrice: 100000,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/email/i);
+  });
+
+  it("returns 400 when productUrl is missing", async () => {
+    mockGetClient.mockReturnValue(makeSupabaseMock());
+    const req = makeRequest({
+      email: "user@example.com",
+      productName: "iPhone",
+      currentPrice: 100000,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 when alert limit (10) is reached", async () => {
+    const supabase = {
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        is: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        single: jest
+          .fn()
+          .mockResolvedValue({ data: { count: 10 }, error: null }),
+        upsert: jest.fn().mockReturnValue({
+          onConflict: jest.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    };
+    mockGetClient.mockReturnValue(supabase);
+
+    const req = makeRequest({
+      email: "user@example.com",
+      productUrl: "https://store.com/p/new",
+      productName: "New Product",
+      currentPrice: 50000,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body.error).toMatch(/limit/i);
+  });
+
+  it("returns 200 { ok: true } on successful new subscription", async () => {
+    const supabase = {
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        is: jest.fn().mockReturnThis(),
+        limit: jest.fn().mockReturnThis(),
+        single: jest
+          .fn()
+          .mockResolvedValue({ data: { count: 0 }, error: null }),
+        upsert: jest.fn().mockReturnValue({
+          onConflict: jest.fn().mockResolvedValue({ error: null }),
+        }),
+      }),
+    };
+    mockGetClient.mockReturnValue(supabase);
+
+    const req = makeRequest({
+      email: "user@example.com",
+      productUrl: "https://store.com/p/1",
+      productName: "iPhone",
+      currentPrice: 100000,
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+  });
+});

--- a/src/app/api/price-alerts/route.ts
+++ b/src/app/api/price-alerts/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseClient } from "@/platform/supabase";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_ALERTS_PER_EMAIL = 10;
+
+export async function POST(request: NextRequest) {
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    return NextResponse.json(
+      { error: "Service temporarily unavailable" },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const { email, productUrl, productName, currentPrice } = body as Record<
+    string,
+    unknown
+  >;
+
+  if (!email || typeof email !== "string" || !EMAIL_RE.test(email)) {
+    return NextResponse.json(
+      { error: "Invalid or missing email address" },
+      { status: 400 },
+    );
+  }
+
+  if (!productUrl || typeof productUrl !== "string") {
+    return NextResponse.json(
+      { error: "productUrl is required" },
+      { status: 400 },
+    );
+  }
+
+  if (!productName || typeof productName !== "string") {
+    return NextResponse.json(
+      { error: "productName is required" },
+      { status: 400 },
+    );
+  }
+
+  if (typeof currentPrice !== "number") {
+    return NextResponse.json(
+      { error: "currentPrice must be a number" },
+      { status: 400 },
+    );
+  }
+
+  // Enforce max 10 active alerts per email
+  const { data: countData, error: countError } = await supabase
+    .from("price_alerts")
+    .select("count")
+    .eq("email", email)
+    .is("unsubscribed_at", null)
+    .limit(1)
+    .single();
+
+  if (
+    !countError &&
+    countData &&
+    (countData as { count: number }).count >= MAX_ALERTS_PER_EMAIL
+  ) {
+    return NextResponse.json(
+      {
+        error: `Alert limit reached (max ${MAX_ALERTS_PER_EMAIL} active alerts per email)`,
+      },
+      { status: 429 },
+    );
+  }
+
+  const { error: upsertError } = await supabase.from("price_alerts").upsert(
+    {
+      email,
+      product_url: productUrl,
+      product_name: productName,
+      last_known_price: currentPrice,
+    },
+    { onConflict: "email,product_url" },
+  );
+
+  if (upsertError) {
+    console.error("[price-alerts] upsert error:", upsertError);
+    return NextResponse.json(
+      { error: "Failed to save alert" },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/price-alerts/unsubscribe/__tests__/route.test.ts
+++ b/src/app/api/price-alerts/unsubscribe/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+/** @jest-environment node */
+import { GET } from "../route";
+import { NextRequest } from "next/server";
+
+jest.mock("@/platform/supabase", () => ({
+  getSupabaseClient: jest.fn(),
+}));
+
+jest.mock("@/platform/alerts/token", () => ({
+  verifyToken: jest.fn(),
+}));
+
+import { getSupabaseClient } from "@/platform/supabase";
+import { verifyToken } from "@/platform/alerts/token";
+
+const mockGetClient = getSupabaseClient as jest.Mock;
+const mockVerifyToken = verifyToken as jest.Mock;
+
+function makeRequest(params: {
+  email?: string;
+  url?: string;
+  token?: string;
+}): NextRequest {
+  const searchParams = new URLSearchParams();
+  if (params.email) searchParams.set("email", params.email);
+  if (params.url) searchParams.set("url", params.url);
+  if (params.token) searchParams.set("token", params.token);
+  return new NextRequest(
+    `http://localhost/api/price-alerts/unsubscribe?${searchParams.toString()}`,
+  );
+}
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("GET /api/price-alerts/unsubscribe", () => {
+  it("returns 400 when token is invalid", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    mockGetClient.mockReturnValue({});
+
+    const req = makeRequest({
+      email: "user@example.com",
+      url: "https://store.com/p/1",
+      token: "invalid-token",
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 503 when Supabase client is null", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    mockGetClient.mockReturnValue(null);
+
+    const req = makeRequest({
+      email: "user@example.com",
+      url: "https://store.com/p/1",
+      token: "valid-token",
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 200 HTML confirmation on valid token and successful update", async () => {
+    mockVerifyToken.mockReturnValue(true);
+    const updateFn = jest.fn().mockReturnThis();
+    const eqUrlFn = jest.fn().mockResolvedValue({ error: null });
+    const supabase = {
+      from: jest.fn().mockReturnValue({
+        update: updateFn,
+        eq: jest
+          .fn()
+          .mockReturnValueOnce({ eq: eqUrlFn })
+          .mockReturnValueOnce({ eq: eqUrlFn }),
+      }),
+    };
+    mockGetClient.mockReturnValue(supabase);
+
+    const req = makeRequest({
+      email: "user@example.com",
+      url: "https://store.com/p/1",
+      token: "valid-token",
+    });
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const contentType = res.headers.get("content-type");
+    expect(contentType).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("Dejaste de seguir");
+  });
+
+  it("returns 400 when required query params are missing", async () => {
+    mockVerifyToken.mockReturnValue(false);
+    const req = makeRequest({ email: "user@example.com" }); // missing url and token
+    const res = await GET(req);
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/app/api/price-alerts/unsubscribe/route.ts
+++ b/src/app/api/price-alerts/unsubscribe/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseClient } from "@/platform/supabase";
+import { verifyToken } from "@/platform/alerts/token";
+
+const CONFIRMATION_HTML = `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Seguimiento cancelado</title>
+</head>
+<body style="font-family:sans-serif;background:#f4f4f5;margin:0;padding:48px 16px;text-align:center;">
+  <div style="max-width:480px;margin:0 auto;background:#fff;border-radius:8px;padding:40px;">
+    <h1 style="font-size:20px;color:#18181b;margin:0 0 16px;">Dejaste de seguir este producto.</h1>
+    <p style="color:#52525b;margin:0;">Ya no recibirás alertas de precio para este producto.</p>
+  </div>
+</body>
+</html>`;
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const email = searchParams.get("email") ?? "";
+  const url = searchParams.get("url") ?? "";
+  const token = searchParams.get("token") ?? "";
+
+  if (!email || !url || !token) {
+    return new NextResponse("Missing required parameters", { status: 400 });
+  }
+
+  if (!verifyToken(email, url, token)) {
+    return new NextResponse("Invalid token", { status: 400 });
+  }
+
+  const supabase = getSupabaseClient();
+  if (!supabase) {
+    return new NextResponse("Service temporarily unavailable", { status: 503 });
+  }
+
+  const { error } = await supabase
+    .from("price_alerts")
+    .update({ unsubscribed_at: new Date().toISOString() })
+    .eq("email", email)
+    .eq("product_url", url);
+
+  if (error) {
+    console.error("[price-alerts/unsubscribe] update error:", error);
+    return new NextResponse("Failed to process unsubscribe", { status: 500 });
+  }
+
+  return new NextResponse(CONFIRMATION_HTML, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}

--- a/src/features/price-alerts/__tests__/email.test.ts
+++ b/src/features/price-alerts/__tests__/email.test.ts
@@ -1,0 +1,38 @@
+/** @jest-environment node */
+import { ALERT_EMAIL_KEY, getStoredEmail, setStoredEmail } from "../email";
+
+const mockStorage: Record<string, string> = {};
+
+beforeEach(() => {
+  Object.keys(mockStorage).forEach((k) => delete mockStorage[k]);
+});
+
+describe("ALERT_EMAIL_KEY", () => {
+  it("is the expected localStorage key", () => {
+    expect(ALERT_EMAIL_KEY).toBe("qdm:alert-email");
+  });
+});
+
+describe("getStoredEmail", () => {
+  it("returns null when key is absent", () => {
+    expect(getStoredEmail(mockStorage)).toBeNull();
+  });
+
+  it("returns the stored email when present", () => {
+    mockStorage[ALERT_EMAIL_KEY] = "user@example.com";
+    expect(getStoredEmail(mockStorage)).toBe("user@example.com");
+  });
+});
+
+describe("setStoredEmail", () => {
+  it("writes email to storage under the correct key", () => {
+    setStoredEmail(mockStorage, "test@example.com");
+    expect(mockStorage[ALERT_EMAIL_KEY]).toBe("test@example.com");
+  });
+
+  it("overwrites a previously stored email", () => {
+    mockStorage[ALERT_EMAIL_KEY] = "old@example.com";
+    setStoredEmail(mockStorage, "new@example.com");
+    expect(mockStorage[ALERT_EMAIL_KEY]).toBe("new@example.com");
+  });
+});

--- a/src/features/price-alerts/alertApi.ts
+++ b/src/features/price-alerts/alertApi.ts
@@ -1,0 +1,26 @@
+import type { AlertProduct, SubscribeResult } from "./types";
+
+export async function subscribeAlert(
+  email: string,
+  product: AlertProduct,
+): Promise<SubscribeResult> {
+  const res = await fetch("/api/price-alerts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      email,
+      productUrl: product.url,
+      productName: product.name,
+      currentPrice: product.price,
+    }),
+  });
+
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(
+      (data as { error?: string }).error ?? `Request failed: ${res.status}`,
+    );
+  }
+
+  return res.json() as Promise<SubscribeResult>;
+}

--- a/src/features/price-alerts/email.ts
+++ b/src/features/price-alerts/email.ts
@@ -1,0 +1,12 @@
+export const ALERT_EMAIL_KEY = "qdm:alert-email";
+
+export function getStoredEmail(storage: Record<string, string>): string | null {
+  return storage[ALERT_EMAIL_KEY] ?? null;
+}
+
+export function setStoredEmail(
+  storage: Record<string, string>,
+  email: string,
+): void {
+  storage[ALERT_EMAIL_KEY] = email;
+}

--- a/src/features/price-alerts/types.ts
+++ b/src/features/price-alerts/types.ts
@@ -1,0 +1,28 @@
+export interface AlertProduct {
+  url: string;
+  name: string;
+  price: number;
+}
+
+export interface SubscribeResult {
+  ok: boolean;
+  deduped?: boolean;
+}
+
+export interface PriceAlert {
+  id: string;
+  email: string;
+  product_url: string;
+  product_name: string;
+  last_known_price: number;
+  created_at: string;
+  notified_at: string | null;
+  unsubscribed_at: string | null;
+}
+
+export interface CreateAlertInput {
+  email: string;
+  productUrl: string;
+  productName: string;
+  currentPrice: number;
+}

--- a/src/platform/alerts/__tests__/token.test.ts
+++ b/src/platform/alerts/__tests__/token.test.ts
@@ -1,0 +1,64 @@
+/** @jest-environment node */
+import { signToken, verifyToken } from "../token";
+
+const TEST_SECRET = "test-secret-abc123";
+
+beforeEach(() => {
+  process.env.ALERT_TOKEN_SECRET = TEST_SECRET;
+});
+
+afterEach(() => {
+  delete process.env.ALERT_TOKEN_SECRET;
+});
+
+describe("signToken", () => {
+  it("returns a non-empty hex string", () => {
+    const token = signToken("user@example.com", "https://store.com/p/123");
+    expect(token).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("returns the same token for the same inputs (deterministic)", () => {
+    const t1 = signToken("user@example.com", "https://store.com/p/123");
+    const t2 = signToken("user@example.com", "https://store.com/p/123");
+    expect(t1).toBe(t2);
+  });
+});
+
+describe("verifyToken", () => {
+  it("returns true for a valid round-trip token", () => {
+    const email = "user@example.com";
+    const url = "https://store.com/p/123";
+    const token = signToken(email, url);
+    expect(verifyToken(email, url, token)).toBe(true);
+  });
+
+  it("returns false when the token is tampered", () => {
+    const email = "user@example.com";
+    const url = "https://store.com/p/123";
+    const token = signToken(email, url);
+    const tampered = token.replace(/.$/, token.endsWith("a") ? "b" : "a");
+    expect(verifyToken(email, url, tampered)).toBe(false);
+  });
+
+  it("returns false when email differs from what was signed", () => {
+    const token = signToken("real@example.com", "https://store.com/p/123");
+    expect(
+      verifyToken("evil@example.com", "https://store.com/p/123", token),
+    ).toBe(false);
+  });
+
+  it("returns false when url differs from what was signed", () => {
+    const token = signToken("user@example.com", "https://store.com/p/123");
+    expect(
+      verifyToken("user@example.com", "https://store.com/p/other", token),
+    ).toBe(false);
+  });
+
+  it("returns false when ALERT_TOKEN_SECRET is missing", () => {
+    delete process.env.ALERT_TOKEN_SECRET;
+    const token = "a".repeat(64);
+    expect(
+      verifyToken("user@example.com", "https://store.com/p/123", token),
+    ).toBe(false);
+  });
+});

--- a/src/platform/alerts/token.ts
+++ b/src/platform/alerts/token.ts
@@ -1,0 +1,27 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+export function signToken(email: string, productUrl: string): string {
+  const secret = process.env.ALERT_TOKEN_SECRET;
+  if (!secret) {
+    throw new Error("ALERT_TOKEN_SECRET is not set");
+  }
+  return createHmac("sha256", secret)
+    .update(`${email}:${productUrl}`)
+    .digest("hex");
+}
+
+export function verifyToken(
+  email: string,
+  productUrl: string,
+  token: string,
+): boolean {
+  try {
+    const expected = signToken(email, productUrl);
+    const expectedBuf = Buffer.from(expected, "hex");
+    const tokenBuf = Buffer.from(token, "hex");
+    if (expectedBuf.length !== tokenBuf.length) return false;
+    return timingSafeEqual(expectedBuf, tokenBuf);
+  } catch {
+    return false;
+  }
+}

--- a/src/platform/email/__tests__/client.test.ts
+++ b/src/platform/email/__tests__/client.test.ts
@@ -1,0 +1,21 @@
+/** @jest-environment node */
+
+describe("getResendClient", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.RESEND_API_KEY;
+  });
+
+  it("returns null when RESEND_API_KEY is absent", async () => {
+    const { getResendClient } = await import("../client");
+    expect(getResendClient()).toBeNull();
+  });
+
+  it("returns a Resend instance when RESEND_API_KEY is set", async () => {
+    process.env.RESEND_API_KEY = "re_test_key";
+    const { getResendClient } = await import("../client");
+    const client = getResendClient();
+    expect(client).not.toBeNull();
+    expect(typeof client).toBe("object");
+  });
+});

--- a/src/platform/email/__tests__/priceDropEmail.test.ts
+++ b/src/platform/email/__tests__/priceDropEmail.test.ts
@@ -1,0 +1,59 @@
+/** @jest-environment node */
+import { renderPriceDropEmail } from "../priceDropEmail";
+
+const BASE_INPUT = {
+  productName: "iPhone 15 Pro",
+  productUrl: "https://store.com/products/iphone-15-pro",
+  oldPrice: 1200000,
+  newPrice: 999000,
+  unsubscribeUrl:
+    "https://quiendamenos.vercel.app/api/price-alerts/unsubscribe?email=u%40e.com&url=...&token=abc",
+};
+
+describe("renderPriceDropEmail — subject", () => {
+  it("uses the correct subject pattern with product name", () => {
+    const { subject } = renderPriceDropEmail(BASE_INPUT);
+    expect(subject).toBe("El precio de iPhone 15 Pro bajó");
+  });
+
+  it("includes the product name in the subject for a different product", () => {
+    const { subject } = renderPriceDropEmail({
+      ...BASE_INPUT,
+      productName: "Samsung Galaxy S24",
+    });
+    expect(subject).toBe("El precio de Samsung Galaxy S24 bajó");
+  });
+});
+
+describe("renderPriceDropEmail — html body", () => {
+  it("includes the old price formatted in ARS", () => {
+    const { html } = renderPriceDropEmail(BASE_INPUT);
+    // Verify oldPrice (1200000) appears somewhere in the body
+    expect(html).toContain("1.200.000");
+  });
+
+  it("includes the new price formatted in ARS", () => {
+    const { html } = renderPriceDropEmail(BASE_INPUT);
+    expect(html).toContain("999.000");
+  });
+
+  it("includes the product URL as a link", () => {
+    const { html } = renderPriceDropEmail(BASE_INPUT);
+    expect(html).toContain(BASE_INPUT.productUrl);
+  });
+
+  it("includes the unsubscribe URL", () => {
+    const { html } = renderPriceDropEmail(BASE_INPUT);
+    expect(html).toContain(BASE_INPUT.unsubscribeUrl);
+  });
+
+  it("includes a Ver oferta call-to-action", () => {
+    const { html } = renderPriceDropEmail(BASE_INPUT);
+    expect(html).toContain("Ver oferta");
+  });
+
+  it("includes the product name in the body", () => {
+    const { html } = renderPriceDropEmail(BASE_INPUT);
+    expect(html).toContain(BASE_INPUT.productName);
+  });
+});

--- a/src/platform/email/client.ts
+++ b/src/platform/email/client.ts
@@ -1,0 +1,11 @@
+import { Resend } from "resend";
+
+let resendClient: Resend | null = null;
+
+export function getResendClient(): Resend | null {
+  if (resendClient) return resendClient;
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) return null;
+  resendClient = new Resend(apiKey);
+  return resendClient;
+}

--- a/src/platform/email/priceDropEmail.ts
+++ b/src/platform/email/priceDropEmail.ts
@@ -1,0 +1,81 @@
+export interface PriceDropEmailInput {
+  productName: string;
+  productUrl: string;
+  oldPrice: number;
+  newPrice: number;
+  unsubscribeUrl: string;
+}
+
+function formatARS(cents: number): string {
+  return new Intl.NumberFormat("es-AR", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(cents);
+}
+
+function calcDropPercent(oldPrice: number, newPrice: number): number {
+  if (oldPrice === 0) return 0;
+  return Math.round(((oldPrice - newPrice) / oldPrice) * 100);
+}
+
+export function renderPriceDropEmail(input: PriceDropEmailInput): {
+  subject: string;
+  html: string;
+} {
+  const { productName, productUrl, oldPrice, newPrice, unsubscribeUrl } = input;
+  const subject = `El precio de ${productName} bajó`;
+  const drop = calcDropPercent(oldPrice, newPrice);
+
+  const html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>${subject}</title>
+</head>
+<body style="font-family:sans-serif;background:#f4f4f5;margin:0;padding:0;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;padding:32px 0;">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:8px;overflow:hidden;">
+          <tr>
+            <td style="background:#18181b;padding:24px;text-align:center;">
+              <span style="color:#fff;font-size:20px;font-weight:700;">quiendamenos</span>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:32px;">
+              <h1 style="font-size:22px;color:#18181b;margin:0 0 16px;">${subject}</h1>
+              <p style="color:#52525b;margin:0 0 24px;">
+                El producto <strong>${productName}</strong> que estás siguiendo bajó de precio.
+              </p>
+              <table width="100%" cellpadding="0" cellspacing="0" style="background:#f4f4f5;border-radius:6px;padding:20px;margin:0 0 24px;">
+                <tr>
+                  <td style="color:#71717a;font-size:14px;">Precio anterior</td>
+                  <td align="right" style="color:#71717a;font-size:14px;text-decoration:line-through;">$ ${formatARS(oldPrice)}</td>
+                </tr>
+                <tr>
+                  <td style="color:#18181b;font-size:22px;font-weight:700;padding-top:8px;">Nuevo precio</td>
+                  <td align="right" style="color:#16a34a;font-size:22px;font-weight:700;padding-top:8px;">$ ${formatARS(newPrice)}</td>
+                </tr>
+                ${drop > 0 ? `<tr><td colspan="2" style="color:#16a34a;font-size:13px;padding-top:4px;">▼ ${drop}% de descuento</td></tr>` : ""}
+              </table>
+              <div style="text-align:center;margin:0 0 32px;">
+                <a href="${productUrl}" style="display:inline-block;background:#18181b;color:#fff;font-size:16px;font-weight:600;padding:14px 32px;border-radius:6px;text-decoration:none;">Ver oferta</a>
+              </div>
+              <hr style="border:none;border-top:1px solid #e4e4e7;margin:0 0 24px;" />
+              <p style="color:#a1a1aa;font-size:12px;text-align:center;margin:0;">
+                Recibís este email porque seguís el precio de <strong>${productName}</strong> en quiendamenos.<br />
+                <a href="${unsubscribeUrl}" style="color:#a1a1aa;">Dejar de seguir este producto</a>
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+
+  return { subject, html };
+}

--- a/supabase/migrations/002_price_alerts.sql
+++ b/supabase/migrations/002_price_alerts.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS price_alerts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT NOT NULL,
+  product_url TEXT NOT NULL,
+  product_name TEXT NOT NULL,
+  last_known_price INTEGER NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  notified_at TIMESTAMPTZ,
+  unsubscribed_at TIMESTAMPTZ,
+  UNIQUE (email, product_url)
+);
+
+CREATE INDEX IF NOT EXISTS idx_price_alerts_active
+  ON price_alerts (email)
+  WHERE unsubscribed_at IS NULL;
+
+ALTER TABLE price_alerts ENABLE ROW LEVEL SECURITY;
+
+-- Only the service role (API routes) may access this table.
+-- No public policy is created intentionally.


### PR DESCRIPTION
## Summary

Backend foundation for the anonymous email price-drop alerts feature (PR 1 of 2).

- **`src/features/price-alerts/types.ts`** — domain interfaces (`PriceAlert`, `CreateAlertInput`, `SubscribeResult`)
- **`src/features/price-alerts/email.ts`** — pure localStorage helpers for storing the user's email (`qdm:alert-email`)
- **`src/features/price-alerts/alertApi.ts`** — client-side `subscribeAlert()` fetch wrapper
- **`src/platform/alerts/token.ts`** — HMAC-SHA256 `signToken`/`verifyToken` for unsubscribe links
- **`src/platform/email/client.ts`** — nullable Resend singleton
- **`src/platform/email/priceDropEmail.ts`** — HTML email renderer (product name, old→new price, unsubscribe link)
- **`src/app/api/price-alerts/route.ts`** — POST: validates email, enforces 10-alert limit, upserts to Supabase
- **`src/app/api/price-alerts/unsubscribe/route.ts`** — GET: verifies HMAC token, soft-deletes alert
- **`supabase/migrations/002_price_alerts.sql`** — `price_alerts` table with RLS
- **`.env.example`** — documents new env vars

## New env vars needed
```
SUPABASE_URL=
SUPABASE_SERVICE_ROLE_KEY=
ALERT_TOKEN_SECRET=
RESEND_API_KEY=
BASE_URL=https://quiendamenos.vercel.app
```

## Test plan

- [x] 262 tests passing (`npm test`) — 32 new, 0 regressions
- [x] 0 lint errors (`npm run lint`)
- [x] Supabase migration applied (`supabase/migrations/002_price_alerts.sql`)
- [x] Env vars set in Vercel (production)

## PR 2 (depends on this)
Will add: `PriceAlertDialog`, `ProductDetailPanel` wiring, `/api/cron/check-prices`, `vercel.json` cron config.