### PR TITLE
feat(ui): PriceAlertDialog, ProductDetailPanel wiring, and daily price-check cron

### DIFF
--- a/src/app/api/cron/check-prices/__tests__/route.test.ts
+++ b/src/app/api/cron/check-prices/__tests__/route.test.ts
@@ -1,0 +1,114 @@
+/** @jest-environment node */
+
+// Set env vars before module imports
+process.env.CRON_SECRET = "test-secret";
+process.env.ALERT_TOKEN_SECRET = "test-token-secret";
+process.env.BASE_URL = "https://quiendamenos.com";
+
+jest.mock("@/platform/supabase", () => ({
+  getSupabaseClient: jest.fn(),
+}));
+
+jest.mock("@/features/price-search/service", () => ({
+  scrapeWebsite: jest.fn(),
+}));
+
+jest.mock("@/platform/email/client", () => ({
+  getResendClient: jest.fn(),
+}));
+
+import type { NextRequest } from "next/server";
+import { GET } from "../route";
+import { getSupabaseClient } from "@/platform/supabase";
+import { scrapeWebsite } from "@/features/price-search/service";
+import { getResendClient } from "@/platform/email/client";
+
+const mockGetSupabaseClient = getSupabaseClient as unknown as jest.Mock;
+const mockScrapeWebsite = scrapeWebsite as unknown as jest.Mock;
+const mockGetResendClient = getResendClient as unknown as jest.Mock;
+
+function makeRequest(authHeader?: string): NextRequest {
+  const headers: Record<string, string> = {};
+  if (authHeader !== undefined) {
+    headers["Authorization"] = authHeader;
+  }
+  return new Request("https://quiendamenos.com/api/cron/check-prices", {
+    headers,
+  }) as unknown as NextRequest;
+}
+
+describe("GET /api/cron/check-prices", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when Authorization header is missing", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when Authorization header has wrong token", async () => {
+    const res = await GET(makeRequest("Bearer wrong-token"));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 503 when Supabase client is null", async () => {
+    mockGetSupabaseClient.mockReturnValue(null);
+    const res = await GET(makeRequest("Bearer test-secret"));
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 200 with checked/notified/skipped on happy path", async () => {
+    const mockAlert = {
+      id: "1",
+      email: "user@example.com",
+      product_url: "https://store.com/product/123",
+      product_name: "iPhone 15 Pro",
+      last_known_price: 1000,
+      created_at: "2024-01-01T00:00:00Z",
+      notified_at: null,
+      unsubscribed_at: null,
+    };
+
+    const mockProduct = {
+      url: "https://store.com/product/123",
+      name: "iPhone 15 Pro",
+      price: 900,
+    };
+
+    const mockUpdateChain = {
+      eq: jest.fn().mockResolvedValue({ error: null }),
+    };
+    const mockSupabase = {
+      from: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          is: jest.fn().mockResolvedValue({ data: [mockAlert], error: null }),
+        }),
+        update: jest.fn().mockReturnValue(mockUpdateChain),
+      }),
+    };
+
+    mockGetSupabaseClient.mockReturnValue(mockSupabase);
+    mockScrapeWebsite.mockResolvedValue([mockProduct]);
+
+    const mockResend = {
+      emails: {
+        send: jest
+          .fn()
+          .mockResolvedValue({ data: { id: "email-1" }, error: null }),
+      },
+    };
+    mockGetResendClient.mockReturnValue(mockResend);
+
+    const res = await GET(makeRequest("Bearer test-secret"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toHaveProperty("checked");
+    expect(body).toHaveProperty("notified");
+    expect(body).toHaveProperty("skipped");
+    expect(typeof body.checked).toBe("number");
+    expect(typeof body.notified).toBe("number");
+    expect(typeof body.skipped).toBe("number");
+  });
+});

--- a/src/app/api/cron/check-prices/route.ts
+++ b/src/app/api/cron/check-prices/route.ts
@@ -1,0 +1,130 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getSupabaseClient } from "@/platform/supabase";
+import { scrapeWebsite } from "@/features/price-search/service";
+import { getResendClient } from "@/platform/email/client";
+import { renderPriceDropEmail } from "@/platform/email/priceDropEmail";
+import { signToken } from "@/platform/alerts/token";
+import type { PriceAlert } from "@/features/price-alerts/types";
+
+export async function GET(req: NextRequest) {
+  try {
+    // 1. Auth check
+    const authHeader = req.headers.get("Authorization");
+    const expected = `Bearer ${process.env.CRON_SECRET}`;
+    if (!authHeader || authHeader !== expected) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // 2. Supabase client
+    const supabase = getSupabaseClient();
+    if (!supabase) {
+      return NextResponse.json(
+        { error: "Supabase unavailable" },
+        { status: 503 },
+      );
+    }
+
+    // 3. Load active alerts
+    const { data: alerts, error: fetchError } = await supabase
+      .from("price_alerts")
+      .select("*")
+      .is("unsubscribed_at", null);
+
+    if (fetchError) {
+      throw fetchError;
+    }
+
+    const activeAlerts = (alerts ?? []) as PriceAlert[];
+
+    // 4. Group by product_name to avoid re-scraping the same product
+    const byName = new Map<string, PriceAlert[]>();
+    for (const alert of activeAlerts) {
+      const group = byName.get(alert.product_name) ?? [];
+      group.push(alert);
+      byName.set(alert.product_name, group);
+    }
+
+    let checked = 0;
+    let notified = 0;
+    let skipped = 0;
+
+    const resend = getResendClient();
+    const baseUrl = process.env.BASE_URL ?? "";
+
+    for (const [productName, group] of byName) {
+      // 5. Scrape once per product name
+      let offers: { url?: string; price?: number; name?: string }[] = [];
+      try {
+        offers = await scrapeWebsite(productName);
+      } catch {
+        skipped += group.length;
+        continue;
+      }
+
+      for (const alert of group) {
+        checked++;
+
+        // Find matching offer by URL
+        const offer = offers.find((o) => o.url === alert.product_url);
+
+        if (!offer || offer.price == null) {
+          // 6. Offer not found — skip, no false alert
+          skipped++;
+          continue;
+        }
+
+        const currentPrice = offer.price;
+        const didDrop = currentPrice < alert.last_known_price;
+
+        if (didDrop) {
+          // 7. Price dropped — send email + update notified_at and last_known_price
+          if (resend) {
+            try {
+              const token = signToken(alert.email, alert.product_url);
+              const unsubscribeUrl = `${baseUrl}/api/price-alerts/unsubscribe?token=${token}&email=${encodeURIComponent(alert.email)}&url=${encodeURIComponent(alert.product_url)}`;
+              const { subject, html } = renderPriceDropEmail({
+                productName: alert.product_name,
+                productUrl: alert.product_url,
+                oldPrice: alert.last_known_price,
+                newPrice: currentPrice,
+                unsubscribeUrl,
+              });
+
+              await resend.emails.send({
+                from: "quiendamenos <no-reply@quiendamenos.com>",
+                to: alert.email,
+                subject,
+                html,
+              });
+              notified++;
+            } catch {
+              // Email send failed — still update DB
+            }
+          }
+
+          await supabase
+            .from("price_alerts")
+            .update({
+              notified_at: new Date().toISOString(),
+              last_known_price: currentPrice,
+            })
+            .eq("id", alert.id);
+        } else {
+          // 8. Price unchanged or raised — update baseline only, no email
+          await supabase
+            .from("price_alerts")
+            .update({ last_known_price: currentPrice })
+            .eq("id", alert.id);
+        }
+      }
+    }
+
+    return NextResponse.json({ checked, notified, skipped }, { status: 200 });
+  } catch (err) {
+    console.error("[check-prices cron] error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/PriceAlertDialog/PriceAlertDialog.stories.tsx
+++ b/src/components/PriceAlertDialog/PriceAlertDialog.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { PriceAlertDialog } from "./PriceAlertDialog";
+
+/**
+ * Dialog controlled para capturar el email del usuario y suscribirlo
+ * a alertas de bajada de precio de un producto determinado.
+ */
+const meta = {
+  title: "Components/PriceAlertDialog",
+  component: PriceAlertDialog,
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    onOpenChange: () => {},
+    onSubmit: async () => {},
+  },
+} satisfies Meta<typeof PriceAlertDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Estado por defecto con el diálogo abierto. */
+export const Default: Story = {
+  args: {
+    productName: "iPhone 15 Pro 256GB",
+  },
+};
+
+/** Con un email pre-cargado del localStorage. */
+export const WithDefaultEmail: Story = {
+  args: {
+    productName: "Samsung Galaxy S24",
+    defaultEmail: "usuario@ejemplo.com",
+  },
+};
+
+/** Mientras se procesa el envío. */
+export const Loading: Story = {
+  args: {
+    productName: "MacBook Air M3",
+    loading: true,
+  },
+};
+
+/** Cuando el servidor devuelve un error. */
+export const WithError: Story = {
+  args: {
+    productName: "Sony WH-1000XM5",
+    error: "No pudimos registrar tu email. Intentá de nuevo.",
+  },
+};
+
+/** Diálogo cerrado — no renderiza nada. */
+export const Closed: Story = {
+  args: {
+    open: false,
+    productName: "Nintendo Switch OLED",
+  },
+};

--- a/src/components/PriceAlertDialog/PriceAlertDialog.tsx
+++ b/src/components/PriceAlertDialog/PriceAlertDialog.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+
+export interface PriceAlertDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  defaultEmail?: string;
+  onSubmit: (email: string) => Promise<void> | void;
+  productName?: string;
+  error?: string;
+  loading?: boolean;
+}
+
+export function PriceAlertDialog({
+  open,
+  onOpenChange,
+  defaultEmail = "",
+  onSubmit,
+  productName,
+  error,
+  loading = false,
+}: PriceAlertDialogProps) {
+  const [email, setEmail] = useState(defaultEmail);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit(email);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Recibí alertas de precio</DialogTitle>
+          <DialogDescription>
+            {productName
+              ? `Te avisamos cuando baje el precio de ${productName}.`
+              : "Te avisamos cuando baje el precio de este producto."}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <input
+            type="email"
+            required
+            placeholder="tu@email.com"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+
+          {error && <p className="text-sm text-destructive">{error}</p>}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="inline-flex w-full items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:pointer-events-none disabled:opacity-50"
+          >
+            {loading ? "Guardando…" : "Seguir precio"}
+          </button>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/PriceAlertDialog/__tests__/PriceAlertDialog.test.tsx
+++ b/src/components/PriceAlertDialog/__tests__/PriceAlertDialog.test.tsx
@@ -1,0 +1,93 @@
+/** @jest-environment node */
+import { renderToStaticMarkup } from "react-dom/server";
+import React from "react";
+
+// Radix Dialog uses browser APIs — stub them for node env
+jest.mock("@/components/ui/dialog", () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const React = require("react");
+  return {
+    Dialog: ({
+      open,
+      children,
+    }: {
+      open?: boolean;
+      children?: React.ReactNode;
+    }) => (open ? React.createElement(React.Fragment, null, children) : null),
+    DialogContent: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "dialog-content" }, children),
+    DialogHeader: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    DialogTitle: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("h2", null, children),
+    DialogDescription: ({ children }: { children?: React.ReactNode }) =>
+      React.createElement("p", null, children),
+  };
+});
+
+import { PriceAlertDialog } from "../PriceAlertDialog";
+
+const noop = () => {};
+const noopAsync = async () => {};
+
+describe("PriceAlertDialog", () => {
+  it("renders nothing when open={false}", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PriceAlertDialog, {
+        open: false,
+        onOpenChange: noop,
+        onSubmit: noopAsync,
+      }),
+    );
+    expect(html).toBe("");
+  });
+
+  it("renders dialog content when open={true}", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PriceAlertDialog, {
+        open: true,
+        onOpenChange: noop,
+        onSubmit: noopAsync,
+      }),
+    );
+    expect(html).toContain("dialog-content");
+    expect(html).toContain("Recibí alertas de precio");
+    expect(html).toContain("Seguir precio");
+  });
+
+  it("shows product name in content when provided", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PriceAlertDialog, {
+        open: true,
+        onOpenChange: noop,
+        onSubmit: noopAsync,
+        productName: "iPhone 15 Pro",
+      }),
+    );
+    expect(html).toContain("iPhone 15 Pro");
+  });
+
+  it("shows error message when error prop is set", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PriceAlertDialog, {
+        open: true,
+        onOpenChange: noop,
+        onSubmit: noopAsync,
+        error: "No pudimos registrar tu email. Intentá de nuevo.",
+      }),
+    );
+    expect(html).toContain("No pudimos registrar tu email. Intentá de nuevo.");
+  });
+
+  it("submit button is disabled when loading={true}", () => {
+    const html = renderToStaticMarkup(
+      React.createElement(PriceAlertDialog, {
+        open: true,
+        onOpenChange: noop,
+        onSubmit: noopAsync,
+        loading: true,
+      }),
+    );
+    expect(html).toContain("disabled");
+  });
+});

--- a/src/components/ProductDetail/ProductDetailPanel.tsx
+++ b/src/components/ProductDetail/ProductDetailPanel.tsx
@@ -13,6 +13,9 @@ import { fetchPriceHistory } from "@/features/price-history/history";
 import { useFollowedProduct } from "@/features/price-follow/useFollowedProduct";
 import { useProductsStore } from "@/store/productsStore";
 import { imageLoader } from "@/features/price-search/image-loader";
+import { PriceAlertDialog } from "@/components/PriceAlertDialog/PriceAlertDialog";
+import { getStoredEmail, setStoredEmail } from "@/features/price-alerts/email";
+import { subscribeAlert } from "@/features/price-alerts/alertApi";
 import type { Product } from "@/types/product.d";
 import type {
   PriceHistoryEntry,
@@ -40,6 +43,59 @@ export function ProductDetailPanel({
   const allProducts = useProductsStore((s) => s.products);
   const [priceHistory, setPriceHistory] = useState<PriceHistoryEntry[]>([]);
   const { isFollowed, toggle } = useFollowedProduct(product.url);
+
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertError, setAlertError] = useState<string | undefined>();
+  const [alertLoading, setAlertLoading] = useState(false);
+
+  const storedEmail =
+    typeof window !== "undefined"
+      ? getStoredEmail(localStorage as unknown as Record<string, string>)
+      : null;
+
+  const handleFollowClick = () => {
+    if (isFollowed) {
+      // Unfollowing — just toggle, no API call
+      toggle();
+      return;
+    }
+    // Following — toggle first for instant feedback
+    toggle();
+    const email = storedEmail;
+    if (email) {
+      // Fire and forget — silently handle error
+      subscribeAlert(email, {
+        url: product.url ?? "",
+        name: product.name ?? "",
+        price: product.price ?? 0,
+      }).catch(() => {});
+    } else {
+      setAlertOpen(true);
+    }
+  };
+
+  const handleAlertSubmit = async (email: string) => {
+    setAlertLoading(true);
+    setAlertError(undefined);
+    try {
+      await subscribeAlert(email, {
+        url: product.url ?? "",
+        name: product.name ?? "",
+        price: product.price ?? 0,
+      });
+      if (typeof window !== "undefined") {
+        setStoredEmail(
+          localStorage as unknown as Record<string, string>,
+          email,
+        );
+      }
+      setAlertOpen(false);
+    } catch {
+      setAlertError("No pudimos registrar tu email. Intentá de nuevo.");
+    } finally {
+      setAlertLoading(false);
+    }
+  };
 
   useEffect(() => {
     if (!currentQuery) return;
@@ -161,7 +217,7 @@ export function ProductDetailPanel({
             <Button
               variant={isFollowed ? "secondary" : "outline"}
               className="rounded-xl px-4 py-3"
-              onClick={toggle}
+              onClick={handleFollowClick}
             >
               {isFollowed ? "✓ Siguiendo" : "♡ Seguir precio"}
             </Button>
@@ -200,6 +256,16 @@ export function ProductDetailPanel({
           )}
         </div>
       </div>
+
+      <PriceAlertDialog
+        open={alertOpen}
+        onOpenChange={setAlertOpen}
+        defaultEmail={storedEmail ?? undefined}
+        onSubmit={handleAlertSubmit}
+        productName={product.name}
+        error={alertError}
+        loading={alertLoading}
+      />
     </div>
   );
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/check-prices",
+      "schedule": "0 12 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Frontend completion for the anonymous email price-drop alerts feature (PR 2 of 2).

- **`src/components/PriceAlertDialog/`** — controlled shadcn dialog for first-time email capture; shows only when `localStorage["qdm:alert-email"]` is absent; returning users bypass it and subscribe directly
- **`src/components/ProductDetail/ProductDetailPanel.tsx`** — orchestrates follow toggle + email capture; `useFollowedProduct` stays localStorage-only (untouched per design)
- **`src/app/api/cron/check-prices/route.ts`** — daily cron (09:00 ART = `0 12 * * *` UTC): loads active alerts, re-scrapes by product name, sends Resend email on price drop, always updates `last_known_price`
- **`vercel.json`** — registers cron schedule

## Test plan

- [x] 271 tests passing (`npm test`) — 9 new, 0 regressions
- [x] 0 lint errors (`npm run lint`)
- [x] 0 TypeScript errors (`tsc --noEmit`)
- [ ] Verify Resend domain configured for `no-reply@quiendamenos.com`
- [ ] Manual smoke test: follow a product, enter email, check Supabase row created

## Depends on
PR #126 (merged) — backend foundation (types, API routes, HMAC token, email renderer, Supabase migration)