### PR TITLE
fix(tests): rename rate-limit test to reflect correct 429 status code

### DIFF
--- a/src/app/api/price-alerts/__tests__/route.test.ts
+++ b/src/app/api/price-alerts/__tests__/route.test.ts
@@ -107,7 +107,7 @@ describe("POST /api/price-alerts", () => {
     expect(res.status).toBe(400);
   });
 
-  it("returns 400 when alert limit (10) is reached", async () => {
+  it("returns 429 when alert limit (10) is reached", async () => {
     const supabase = {
       from: jest.fn().mockReturnValue({
         select: jest.fn().mockReturnThis(),


### PR DESCRIPTION
## Summary

One-line fix: the test description said "returns 400" but was already asserting `status 429`. The code is correct (429 is the proper HTTP status for rate limiting per RFC 6585); the label was misleading.

Found during `sdd-verify` of `seguir-precio-email`.

## Test plan

- [x] `npm test` — 271/271 passing