### PR TITLE
fix(search): accept inch symbol and surface real API errors

### DIFF
--- a/src/features/price-search/__tests__/api.test.ts
+++ b/src/features/price-search/__tests__/api.test.ts
@@ -1,0 +1,125 @@
+import { getProduct } from "../api";
+import { ScrapeApiError } from "../errors";
+
+const okResponse = (body: unknown) =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  }) as unknown as Response;
+
+const errorResponse = (status: number, body: unknown = {}) =>
+  ({
+    ok: false,
+    status,
+    json: async () => body,
+  }) as unknown as Response;
+
+const mockFetch = jest.fn();
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch as unknown as typeof fetch;
+});
+
+describe("getProduct — URL encoding", () => {
+  it('encodes the inch symbol so "samsung 65"" reaches the API intact', async () => {
+    mockFetch.mockResolvedValue(okResponse([]));
+
+    await getProduct('samsung 65"');
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/scrape?query=samsung%2065%22",
+      { method: "GET" },
+    );
+  });
+
+  it("encodes ampersands so the query is not split into two params", async () => {
+    mockFetch.mockResolvedValue(okResponse([]));
+
+    await getProduct("bosch & siemens");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/scrape?query=bosch%20%26%20siemens",
+      { method: "GET" },
+    );
+  });
+
+  it("encodes the hash symbol so the query is not truncated", async () => {
+    mockFetch.mockResolvedValue(okResponse([]));
+
+    await getProduct("tv #1");
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/scrape?query=tv%20%231", {
+      method: "GET",
+    });
+  });
+});
+
+describe("getProduct — success", () => {
+  it("coerces prices to numbers", async () => {
+    mockFetch.mockResolvedValue(
+      okResponse([{ name: "TV", price: "123.45", brand: "samsung" }]),
+    );
+
+    const result = await getProduct("tv");
+
+    expect(result[0].price).toBe(123.45);
+  });
+});
+
+describe("getProduct — error propagation", () => {
+  it("throws ScrapeApiError carrying the HTTP status on 400", async () => {
+    mockFetch.mockResolvedValue(
+      errorResponse(400, { error: "Query contains disallowed characters" }),
+    );
+
+    await expect(getProduct('samsung 65"')).rejects.toBeInstanceOf(
+      ScrapeApiError,
+    );
+  });
+
+  it("reports an invalid search on 400 instead of blaming the connection", async () => {
+    mockFetch.mockResolvedValue(
+      errorResponse(400, { error: "Query contains disallowed characters" }),
+    );
+
+    await expect(getProduct("tv")).rejects.toThrow(
+      "La búsqueda no es válida. Revisá los términos e intentá de nuevo.",
+    );
+  });
+
+  it("reports rate limiting on 429", async () => {
+    mockFetch.mockResolvedValue(errorResponse(429));
+
+    await expect(getProduct("tv")).rejects.toThrow(
+      "Demasiadas búsquedas seguidas. Esperá un momento e intentá de nuevo.",
+    );
+  });
+
+  it("reports a service problem on 500", async () => {
+    mockFetch.mockResolvedValue(errorResponse(500));
+
+    await expect(getProduct("tv")).rejects.toThrow(
+      "El servicio no está disponible en este momento. Intentá de nuevo en unos minutos.",
+    );
+  });
+
+  it("does not fail when the error body is not valid JSON", async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => {
+        throw new SyntaxError("Unexpected token");
+      },
+    } as unknown as Response);
+
+    await expect(getProduct("tv")).rejects.toBeInstanceOf(ScrapeApiError);
+  });
+
+  it("lets a genuine network failure propagate as a non-ScrapeApiError", async () => {
+    mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(getProduct("tv")).rejects.not.toBeInstanceOf(ScrapeApiError);
+  });
+});

--- a/src/features/price-search/api.ts
+++ b/src/features/price-search/api.ts
@@ -1,12 +1,19 @@
 import { Product } from "@/types/product";
+import { ScrapeApiError, userMessageForStatus } from "./errors";
 
 export async function getProduct(productName: string) {
-  const response = await fetch(`/api/scrape?query=${productName}`, {
-    method: "GET",
-  });
+  const response = await fetch(
+    `/api/scrape?query=${encodeURIComponent(productName)}`,
+    {
+      method: "GET",
+    },
+  );
 
   if (!response.ok) {
-    throw new Error("Failed to fetch scrape");
+    throw new ScrapeApiError(
+      userMessageForStatus(response.status),
+      response.status,
+    );
   }
 
   const results = await response.json();

--- a/src/features/price-search/errors.ts
+++ b/src/features/price-search/errors.ts
@@ -1,0 +1,33 @@
+/**
+ * Error raised when /api/scrape answers with a non-OK status.
+ *
+ * Its `message` is a user-facing string already resolved from the HTTP status,
+ * so the UI can show it verbatim. A rejection that is NOT a ScrapeApiError
+ * means the request never got an answer (offline, DNS, aborted connection),
+ * which is the only case where blaming the connection is accurate.
+ */
+export class ScrapeApiError extends Error {
+  readonly status: number;
+
+  constructor(message: string, status: number) {
+    super(message);
+    this.name = "ScrapeApiError";
+    this.status = status;
+  }
+}
+
+export const CONNECTION_ERROR_MESSAGE =
+  "No se pudo conectar. Verificá tu conexión e intentá de nuevo.";
+
+export function userMessageForStatus(status: number): string {
+  if (status === 400) {
+    return "La búsqueda no es válida. Revisá los términos e intentá de nuevo.";
+  }
+  if (status === 429) {
+    return "Demasiadas búsquedas seguidas. Esperá un momento e intentá de nuevo.";
+  }
+  if (status >= 500) {
+    return "El servicio no está disponible en este momento. Intentá de nuevo en unos minutos.";
+  }
+  return "No pudimos completar la búsqueda. Intentá de nuevo.";
+}

--- a/src/platform/query/__tests__/query.test.ts
+++ b/src/platform/query/__tests__/query.test.ts
@@ -1,61 +1,101 @@
-import { validateQuery } from '@/platform/query';
+import { validateQuery } from "@/platform/query";
 
-describe('validateQuery', () => {
+describe("validateQuery", () => {
   it('accepts "Samsung TV 55"', () => {
-    const result = validateQuery('Samsung TV 55');
+    const result = validateQuery("Samsung TV 55");
     expect(result.valid).toBe(true);
-    if (result.valid) expect(result.value).toBe('Samsung TV 55');
+    if (result.valid) expect(result.value).toBe("Samsung TV 55");
   });
 
-  it('rejects a 101-character string (max length exceeded)', () => {
-    const input = 'a'.repeat(101);
+  it("rejects a 101-character string (max length exceeded)", () => {
+    const input = "a".repeat(101);
     const result = validateQuery(input);
     expect(result.valid).toBe(false);
   });
 
-  it('rejects string with carriage return \\r', () => {
-    const result = validateQuery('samsung\rTV');
+  it("rejects string with carriage return \\r", () => {
+    const result = validateQuery("samsung\rTV");
     expect(result.valid).toBe(false);
   });
 
-  it('rejects string with newline \\n', () => {
-    const result = validateQuery('samsung\nTV');
+  it("rejects string with newline \\n", () => {
+    const result = validateQuery("samsung\nTV");
     expect(result.valid).toBe(false);
   });
 
-  it('rejects string with disallowed chars like <script>', () => {
-    const result = validateQuery('tv <script>');
+  it("rejects string with disallowed chars like <script>", () => {
+    const result = validateQuery("tv <script>");
     expect(result.valid).toBe(false);
   });
 
-  it('rejects empty string', () => {
-    const result = validateQuery('');
+  it("rejects empty string", () => {
+    const result = validateQuery("");
     expect(result.valid).toBe(false);
   });
 
-  it('rejects whitespace-only string', () => {
-    const result = validateQuery('   ');
+  it("rejects whitespace-only string", () => {
+    const result = validateQuery("   ");
     expect(result.valid).toBe(false);
   });
 
   it('accepts Spanish characters like "televisión"', () => {
-    const result = validateQuery('televisión');
+    const result = validateQuery("televisión");
     expect(result.valid).toBe(true);
   });
 
-  it('returns trimmed value on success', () => {
-    const result = validateQuery('  Samsung TV  ');
+  it("returns trimmed value on success", () => {
+    const result = validateQuery("  Samsung TV  ");
     expect(result.valid).toBe(true);
-    if (result.valid) expect(result.value).toBe('Samsung TV');
+    if (result.valid) expect(result.value).toBe("Samsung TV");
   });
 
-  it('rejects non-string input', () => {
+  it("rejects non-string input", () => {
     const result = validateQuery(42);
     expect(result.valid).toBe(false);
   });
 
-  it('accepts allowed special chars: - _ . , ( )', () => {
-    const result = validateQuery('TV LED (Samsung), 4K-UHD_2024.');
+  it("accepts allowed special chars: - _ . , ( )", () => {
+    const result = validateQuery("TV LED (Samsung), 4K-UHD_2024.");
     expect(result.valid).toBe(true);
+  });
+
+  it('accepts double quotes used as the inch symbol: "samsung 65""', () => {
+    const result = validateQuery('samsung 65"');
+    expect(result.valid).toBe(true);
+    if (result.valid) expect(result.value).toBe('samsung 65"');
+  });
+
+  it("accepts single quotes", () => {
+    const result = validateQuery("notebook 15'");
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts forward slash: "notebook i5/i7"', () => {
+    const result = validateQuery("notebook i5/i7");
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts plus sign: "smart tv 65+"', () => {
+    const result = validateQuery("smart tv 65+");
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts ampersand in brand names", () => {
+    const result = validateQuery("bosch & siemens");
+    expect(result.valid).toBe(true);
+  });
+
+  it("still rejects angle brackets after widening the allowlist", () => {
+    expect(validateQuery("tv <b>").valid).toBe(false);
+    expect(validateQuery("tv >").valid).toBe(false);
+  });
+
+  it("still rejects backslash and backtick after widening the allowlist", () => {
+    expect(validateQuery("tv \\ 65").valid).toBe(false);
+    expect(validateQuery("tv `65`").valid).toBe(false);
+  });
+
+  it("still rejects line breaks combined with newly allowed chars", () => {
+    expect(validateQuery('samsung 65"\r\nX').valid).toBe(false);
   });
 });

--- a/src/platform/query/index.ts
+++ b/src/platform/query/index.ts
@@ -2,24 +2,36 @@ type ValidResult = { valid: true; value: string };
 type InvalidResult = { valid: false; reason: string };
 type QueryResult = ValidResult | InvalidResult;
 
-const ALLOWED_CHARS = /^[\p{L}\p{N} \-_.,()]+$/u;
+// Allowlist kept as defense-in-depth only: every consumer of the validated
+// value already encodes it (encodeURIComponent in the scrapers, URLSearchParams
+// in the VTEX helpers, SHA256 in the cache keys). The characters below are the
+// ones real product searches need — `"` for inches ("samsung 65\""), `/` for
+// "i5/i7", `&` for brand pairs. Structural characters (< > \ ` ; $ {}) and line
+// breaks stay out.
+const ALLOWED_CHARS = /^[\p{L}\p{N} \-_.,()"'\/+&]+$/u;
 
 export function validateQuery(input: unknown): QueryResult {
-  if (typeof input !== 'string') {
-    return { valid: false, reason: 'Query must be a string' };
+  if (typeof input !== "string") {
+    return { valid: false, reason: "Query must be a string" };
   }
   if (input.length > 100) {
-    return { valid: false, reason: 'Query exceeds maximum length of 100 characters' };
+    return {
+      valid: false,
+      reason: "Query exceeds maximum length of 100 characters",
+    };
   }
   if (/\r|\n/.test(input)) {
-    return { valid: false, reason: 'Query contains invalid line break characters' };
+    return {
+      valid: false,
+      reason: "Query contains invalid line break characters",
+    };
   }
   const trimmed = input.trim();
   if (trimmed.length === 0) {
-    return { valid: false, reason: 'Query cannot be empty' };
+    return { valid: false, reason: "Query cannot be empty" };
   }
   if (!ALLOWED_CHARS.test(trimmed)) {
-    return { valid: false, reason: 'Query contains disallowed characters' };
+    return { valid: false, reason: "Query contains disallowed characters" };
   }
   return { valid: true, value: trimmed };
 }

--- a/src/store/__tests__/productsStore.test.ts
+++ b/src/store/__tests__/productsStore.test.ts
@@ -2,6 +2,7 @@ import { useProductsStore } from "../productsStore";
 import { selectPhase } from "../productsStore";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { ALL } from "@/features/price-search/constants";
+import { ScrapeApiError } from "@/features/price-search/errors";
 
 jest.mock("@/features/price-search/api", () => ({
   getProduct: jest.fn(),
@@ -170,6 +171,47 @@ describe("useProductsStore — estado de error", () => {
 
     expect(useProductsStore.getState().error).not.toBeNull();
     expect(useProductsStore.getState().isLoading).toBe(false);
+  });
+
+  it("getProducts muestra el motivo real de la API en vez de culpar a la conexión", async () => {
+    mockGetProduct.mockRejectedValue(
+      new ScrapeApiError(
+        "La búsqueda no es válida. Revisá los términos e intentá de nuevo.",
+        400,
+      ),
+    );
+
+    await useProductsStore.getState().getProducts('samsung 65"');
+
+    expect(useProductsStore.getState().error).toBe(
+      "La búsqueda no es válida. Revisá los términos e intentá de nuevo.",
+    );
+    expect(useProductsStore.getState().isLoading).toBe(false);
+  });
+
+  it("getProducts propaga el mensaje de rate limiting de la API", async () => {
+    mockGetProduct.mockRejectedValue(
+      new ScrapeApiError(
+        "Demasiadas búsquedas seguidas. Esperá un momento e intentá de nuevo.",
+        429,
+      ),
+    );
+
+    await useProductsStore.getState().getProducts("tv");
+
+    expect(useProductsStore.getState().error).toBe(
+      "Demasiadas búsquedas seguidas. Esperá un momento e intentá de nuevo.",
+    );
+  });
+
+  it("getProducts reserva el mensaje de conexión para fallos de red reales", async () => {
+    mockGetProduct.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await useProductsStore.getState().getProducts("tv");
+
+    expect(useProductsStore.getState().error).toBe(
+      "No se pudo conectar. Verificá tu conexión e intentá de nuevo.",
+    );
   });
 });
 

--- a/src/store/productsStore.ts
+++ b/src/store/productsStore.ts
@@ -1,5 +1,9 @@
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { getProduct } from "@/features/price-search/api";
+import {
+  CONNECTION_ERROR_MESSAGE,
+  ScrapeApiError,
+} from "@/features/price-search/errors";
 import { ALL } from "@/features/price-search/constants";
 import { updateUnknownBrands } from "@/features/price-search/unknown-brands";
 import { capitalize } from "@/lib/capitalize";
@@ -85,10 +89,13 @@ export const useProductsStore = create<State>((set, get) => ({
         isLoading: false,
         error: null,
       }));
-    } catch {
+    } catch (error) {
       set({
         isLoading: false,
-        error: "No se pudo conectar. Verificá tu conexión e intentá de nuevo.",
+        error:
+          error instanceof ScrapeApiError
+            ? error.message
+            : CONNECTION_ERROR_MESSAGE,
       });
     }
   },


### PR DESCRIPTION
## Problem

Searching `samsung 65"` in production returned `400` on `/api/scrape`, and the UI reported:

> Error al cargar resultados — No se pudo conectar. Verificá tu conexión e intentá de nuevo.

The connection was fine. The query was rejected server-side by `validateQuery`, and every layer between the API and the user erased the reason.

Confirmed in production runtime logs: `GET /api/scrape 200` for `samsung 65` at 10:34:16, then `GET /api/scrape 400` at 10:35:31.

## Root causes

| Layer | File | Defect |
|---|---|---|
| Validation | `platform/query/index.ts:5` | Allowlist excluded `"`, `'`, `/`, `+`, `&` |
| Request | `features/price-search/api.ts:4` | Raw interpolation into the URL — `&` splits the query, `#` truncates it |
| Client error | `features/price-search/api.ts:9` | Response body discarded, generic `Error` thrown |
| UI state | `store/productsStore.ts:88` | Bindingless `catch` mapped every failure to the connection message |

## Changes

- **Allowlist widened** to `"` (inches), `'`, `/` (`i5/i7`), `+`, `&` (brand pairs). The 100-char cap, the CRLF ban and structural characters (`< > \ \` ; $ {}`) stay blocked.
- **`encodeURIComponent`** on the query before it reaches the URL.
- **`ScrapeApiError`** (new `features/price-search/errors.ts`) carries a user-facing message resolved from the HTTP status: 400 → invalid search, 429 → rate limited, 5xx → service unavailable.
- **`productsStore`** shows the API reason and reserves `"No se pudo conectar…"` for rejections that are *not* `ScrapeApiError` — i.e. real network failures.

### Why the allowlist is safe to widen

It is defense-in-depth, not the injection boundary. Every consumer of the validated value already encodes it:

| Consumer | Encoding |
|---|---|
| `scrapers/mercadolibre/index.ts:24` | `encodeURIComponent` |
| `scrapers/fravega/index.ts:47` | `encodeURIComponent` |
| `scrapers/parsers/cheerio.parser.ts:28` | `encodeURIComponent` |
| `platform/vtex/helpers.ts:27` | `URLSearchParams` |
| cache keys | SHA256 of the normalized query |

### Why both fixes ship together

Widening the allowlist without the encoding fix would turn a clean `400` into a **silent wrong result**: `samsung 65" & smart tv` would be split at the `&` and the backend would receive `samsung 65"`, returning plausible-but-wrong products with no error at all.

## Tests

TDD — tests written failing first, then the implementation.

- `platform/query/__tests__/query.test.ts` — 8 new cases: newly allowed characters accepted, angle brackets / backslash / backtick / CRLF still rejected.
- `features/price-search/__tests__/api.test.ts` — new suite: encoding of `"`, `&`, `#`; `ScrapeApiError` per status; malformed error body; network failure stays non-`ScrapeApiError`.
- `store/__tests__/productsStore.test.ts` — 3 new cases: API reason surfaced, connection message reserved for real network failures.

`npm test` → 43 suites, 292 tests passing. `npm run lint` clean (one pre-existing warning in `e2e/happy-path.spec.ts`). `npm run build` succeeds.

## Out of scope

Two findings surfaced while investigating production logs, not addressed here:

1. **ScraperAPI key exposed in runtime logs.** `scrapers/fravega/index.ts:109` dumps the full axios error, whose `config.url` contains `api_key=…` in plaintext. `platform/errors/redactError` exists but the scrapers do not use it.
2. **Backoff never retries scraper failures.** Scrapers `catch → console.error → return []`, so backoff sees a valid empty array and logs `✅ Éxito en intento 1/5 (23009ms)` immediately after a Fravega timeout. The 4-retry policy is dead code on this path.