### PR TITLE
fix(logs): redact secrets from error logs instead of dumping raw errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ Comparador de precios de electrónica para tiendas argentinas. Scrapea en parale
 
 ## Tiendas soportadas
 
-| Tienda | Método |
-|--------|--------|
-| Frávega | VTEX IS |
-| Cetrogar | VTEX IS |
-| Naldo | VTEX IS |
-| OnCity | VTEX IS |
-| Carrefour | VTEX IS |
+| Tienda       | Método     |
+| ------------ | ---------- |
+| Frávega      | VTEX IS    |
+| Cetrogar     | VTEX IS    |
+| Naldo        | VTEX IS    |
+| OnCity       | VTEX IS    |
+| Carrefour    | VTEX IS    |
 | MercadoLibre | API propia |
 
 ---
@@ -100,13 +100,13 @@ GET /api/scrape?query=iphone
 
 ### Capas principales
 
-| Capa | Ruta | Responsabilidad |
-|------|------|-----------------|
-| Middleware | `src/proxy.ts` | Rate limiting (10 req/min/IP), API key auth, security headers |
-| Infraestructura | `src/platform/` | Cache Redis, backoff exponencial, clasificación de errores, queue |
-| Dominio | `src/features/price-search/` | Orquestación de scrapers, estado cliente (Zustand) |
-| Scrapers | `src/scrapers/` | Un folder por tienda |
-| UI | `src/components/` | React + shadcn/ui + Storybook |
+| Capa            | Ruta                         | Responsabilidad                                                   |
+| --------------- | ---------------------------- | ----------------------------------------------------------------- |
+| Middleware      | `src/proxy.ts`               | Rate limiting (10 req/min/IP), API key auth, security headers     |
+| Infraestructura | `src/platform/`              | Cache Redis, backoff exponencial, clasificación de errores, queue |
+| Dominio         | `src/features/price-search/` | Orquestación de scrapers, estado cliente (Zustand)                |
+| Scrapers        | `src/scrapers/`              | Un folder por tienda                                              |
+| UI              | `src/components/`            | React + shadcn/ui + Storybook                                     |
 
 ### Caché Redis (dos niveles)
 
@@ -125,21 +125,25 @@ Las tiendas con VTEX Intelligent Search usan el factory:
 
 ```typescript
 import { createVtexScraper } from "@/platform/vtex/helpers";
-export const scrapeNombre = createVtexScraper("https://www.tienda.com.ar", StoreNamesEnum.NOMBRE);
+export const scrapeNombre = createVtexScraper(
+  "https://www.tienda.com.ar",
+  StoreNamesEnum.NOMBRE,
+);
 ```
 
 ---
 
 ## Variables de entorno
 
-| Variable | Entorno | Descripción |
-|----------|---------|-------------|
-| `REDIS_URL` | Local + Prod | Host de Redis (`127.0.0.1` local) |
-| `REDIS_PORT` | Local + Prod | Puerto de Redis (`6379` local) |
-| `REDIS_PASSWORD` | Solo prod | Omitir en local |
-| `API_SECRET_KEY` | Solo prod | Se requiere el header `x-api-key` en prod; en dev se omite |
-| `RESEND_API_KEY` | Solo prod | API key de [Resend](https://resend.com) para alertas por email |
-| `ALERT_EMAIL` | Solo prod | Email destino de las alertas de scrapers caídos |
+| Variable          | Entorno      | Descripción                                                                                                                                    |
+| ----------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REDIS_URL`       | Local + Prod | Host de Redis (`127.0.0.1` local)                                                                                                              |
+| `REDIS_PORT`      | Local + Prod | Puerto de Redis (`6379` local)                                                                                                                 |
+| `REDIS_PASSWORD`  | Solo prod    | Omitir en local                                                                                                                                |
+| `API_SECRET_KEY`  | Solo prod    | Se requiere el header `x-api-key` en prod; en dev se omite                                                                                     |
+| `RESEND_API_KEY`  | Solo prod    | API key de [Resend](https://resend.com) para alertas por email                                                                                 |
+| `ALERT_EMAIL`     | Solo prod    | Email destino de las alertas de scrapers caídos                                                                                                |
+| `SCRAPER_API_KEY` | Opcional     | API key de [ScraperAPI](https://www.scraperapi.com), usada como proxy para Fravega. Sin ella, Fravega se consulta directo y puede devolver 403 |
 
 > `CRON_SECRET` y `VERCEL_PROJECT_PRODUCTION_URL` los genera Vercel automáticamente.
 
@@ -161,10 +165,10 @@ Vercel Cron (*/10 * * * *)
 
 ### Endpoints de health
 
-| Endpoint | Descripción | Auth |
-|----------|-------------|------|
-| `GET /api/health` | Estado de cada scraper en tiempo real | Pública |
-| `GET /api/health-check` | Cron: evalúa y notifica | `CRON_SECRET` (Vercel automático) |
+| Endpoint                | Descripción                           | Auth                              |
+| ----------------------- | ------------------------------------- | --------------------------------- |
+| `GET /api/health`       | Estado de cada scraper en tiempo real | Pública                           |
+| `GET /api/health-check` | Cron: evalúa y notifica               | `CRON_SECRET` (Vercel automático) |
 
 Ejemplo de respuesta de `/api/health`:
 
@@ -172,8 +176,13 @@ Ejemplo de respuesta de `/api/health`:
 {
   "status": "degraded",
   "stores": {
-    "fravega":  { "status": "ok",   "latency": 823,  "count": 12 },
-    "cetrogar": { "status": "down", "latency": 8001, "count": 0, "error": "timeout" }
+    "fravega": { "status": "ok", "latency": 823, "count": 12 },
+    "cetrogar": {
+      "status": "down",
+      "latency": 8001,
+      "count": 0,
+      "error": "timeout"
+    }
   },
   "timestamp": "2026-04-20T14:30:00.000Z"
 }
@@ -185,10 +194,10 @@ Ejemplo de respuesta de `/api/health`:
 
 **2.** En Vercel → quiendamenos → **Settings → Environment Variables**, agregar:
 
-| Variable | Valor |
-|----------|-------|
+| Variable         | Valor            |
+| ---------------- | ---------------- |
 | `RESEND_API_KEY` | La key de Resend |
-| `ALERT_EMAIL` | Tu email |
+| `ALERT_EMAIL`    | Tu email         |
 
 **3.** Hacer deploy — el cron se activa automáticamente al leer `vercel.json`.
 
@@ -196,9 +205,9 @@ Ejemplo de respuesta de `/api/health`:
 
 ## Tests
 
-| Framework | Qué testea | Config |
-|-----------|------------|--------|
-| Jest + ts-jest | `platform/` y `scrapers/` | `jest.config.js` |
+| Framework           | Qué testea                           | Config             |
+| ------------------- | ------------------------------------ | ------------------ |
+| Jest + ts-jest      | `platform/` y `scrapers/`            | `jest.config.js`   |
 | Vitest + Playwright | Storybook component tests + coverage | `vitest.config.ts` |
 
 ---

--- a/src/app/api/scrape/route.ts
+++ b/src/app/api/scrape/route.ts
@@ -3,7 +3,7 @@ import { getQueryCache, setQueryCache, cacheKey } from "@/platform/cache";
 import { scrapeWebsite } from "@/features/price-search/service";
 import { NextRequest, NextResponse } from "next/server";
 import { validateQuery } from "@/platform/query";
-import { redactError } from "@/platform/errors";
+import { redactError, toLogSafeError } from "@/platform/errors";
 
 export async function GET(request: NextRequest) {
   try {
@@ -12,10 +12,7 @@ export async function GET(request: NextRequest) {
     const validation = validateQuery(raw);
 
     if (!validation.valid) {
-      return NextResponse.json(
-        { error: validation.reason },
-        { status: 400 }
-      );
+      return NextResponse.json({ error: validation.reason }, { status: 400 });
     }
 
     const query = validation.value;
@@ -37,7 +34,7 @@ export async function GET(request: NextRequest) {
     await setQueryCache(key, result);
     return NextResponse.json(result);
   } catch (error) {
-    console.error("Error in scrape route:", error);
+    console.error("Error in scrape route:", toLogSafeError(error));
     return NextResponse.json(redactError(error), { status: 500 });
   }
 }

--- a/src/features/price-search/service.ts
+++ b/src/features/price-search/service.ts
@@ -3,6 +3,7 @@ import { scrapers } from "@/scrapers";
 import { getAllStores } from "@/scrapers/registry";
 import { scrapeWithFallback } from "./router";
 import { cacheKey, setStoreCacheNX } from "@/platform/cache";
+import { toLogSafeError } from "@/platform/errors";
 import { batchInsertSnapshots } from "@/features/price-history/insert";
 
 export async function scrapeWebsite(query: string): Promise<Product[]> {
@@ -53,7 +54,7 @@ export async function scrapeWebsite(query: string): Promise<Product[]> {
 
     return allProducts;
   } catch (error) {
-    console.error("Error scraping website:", error);
+    console.error("Error scraping website:", toLogSafeError(error));
     return [];
   }
 }

--- a/src/platform/errors/__tests__/log-safe.test.ts
+++ b/src/platform/errors/__tests__/log-safe.test.ts
@@ -1,0 +1,189 @@
+import { redactSecrets, toLogSafeError } from "../log-safe";
+
+const REDACTED = "***REDACTED***";
+
+describe("redactSecrets — sensitive URL parameters", () => {
+  it("masks api_key, the exact leak seen in the Fravega logs", () => {
+    const url =
+      "https://api.scraperapi.com?api_key=10c72dd259391bcada437333574ed519&url=https%3A%2F%2Fwww.fravega.com";
+
+    const result = redactSecrets(url);
+
+    expect(result).not.toContain("10c72dd259391bcada437333574ed519");
+    expect(result).toContain(`api_key=${REDACTED}`);
+  });
+
+  it("keeps non-sensitive parameters readable so logs stay useful", () => {
+    const url =
+      "https://api.scraperapi.com?api_key=abcdef123456&url=https%3A%2F%2Fwww.fravega.com&limit=50";
+
+    const result = redactSecrets(url);
+
+    expect(result).toContain("limit=50");
+    expect(result).toContain("url=https%3A%2F%2Fwww.fravega.com");
+    expect(result).not.toContain("abcdef123456");
+  });
+
+  it("masks the usual secret parameter names", () => {
+    const names = [
+      "apikey",
+      "access_token",
+      "token",
+      "secret",
+      "client_secret",
+      "password",
+      "authorization",
+      "signature",
+    ];
+
+    for (const name of names) {
+      const result = redactSecrets(`https://x.com/a?${name}=supersecretvalue`);
+      expect(result).not.toContain("supersecretvalue");
+    }
+  });
+
+  it("matches parameter names case-insensitively", () => {
+    const result = redactSecrets("https://x.com/a?API_KEY=supersecretvalue");
+    expect(result).not.toContain("supersecretvalue");
+  });
+
+  it("masks every occurrence, not just the first", () => {
+    const result = redactSecrets(
+      "https://x.com/a?api_key=aaaaaaaa1 https://y.com/b?api_key=bbbbbbbb2",
+    );
+    expect(result).not.toContain("aaaaaaaa1");
+    expect(result).not.toContain("bbbbbbbb2");
+  });
+});
+
+describe("redactSecrets — environment secret values", () => {
+  const originalEnv = process.env;
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("masks a secret env value even when it appears outside a query string", () => {
+    process.env = { ...originalEnv, SCRAPER_API_KEY: "envsecret1234567" };
+
+    const result = redactSecrets(
+      "request failed for token envsecret1234567 in path segment",
+    );
+
+    expect(result).not.toContain("envsecret1234567");
+    expect(result).toContain(REDACTED);
+  });
+
+  it("masks values of any env var whose name looks secret", () => {
+    process.env = {
+      ...originalEnv,
+      API_SECRET_KEY: "apisecretvalue123",
+      REDIS_PASSWORD: "redispassword123",
+      RESEND_API_KEY: "resendkeyvalue123",
+    };
+
+    const result = redactSecrets(
+      "apisecretvalue123 / redispassword123 / resendkeyvalue123",
+    );
+
+    expect(result).not.toContain("apisecretvalue123");
+    expect(result).not.toContain("redispassword123");
+    expect(result).not.toContain("resendkeyvalue123");
+  });
+
+  it("ignores short env values to avoid masking half the log", () => {
+    process.env = { ...originalEnv, SOME_KEY: "dev" };
+
+    const result = redactSecrets("running in dev mode");
+
+    expect(result).toBe("running in dev mode");
+  });
+
+  it("leaves non-secret env values alone", () => {
+    process.env = { ...originalEnv, PUBLIC_BASE_URL: "https://example.com" };
+
+    const result = redactSecrets("calling https://example.com");
+
+    expect(result).toContain("https://example.com");
+  });
+});
+
+describe("toLogSafeError — axios-shaped errors", () => {
+  const axiosError = () => {
+    const error = new Error("timeout of 23000ms exceeded") as Error & {
+      code: string;
+      config: { url: string; method: string; headers: Record<string, string> };
+      request: Record<string, unknown>;
+    };
+    error.name = "AxiosError";
+    error.code = "ECONNABORTED";
+    error.config = {
+      url: "https://api.scraperapi.com?api_key=10c72dd259391bcada437333574ed519&url=https%3A%2F%2Fwww.fravega.com",
+      method: "get",
+      headers: { Referer: "https://www.fravega.com/" },
+    };
+    error.request = { _header: "GET / HTTP/1.1", socket: { authorized: true } };
+    return error;
+  };
+
+  it("never leaks the api key present in config.url", () => {
+    const result = toLogSafeError(axiosError());
+    expect(result).not.toContain("10c72dd259391bcada437333574ed519");
+  });
+
+  it("keeps the diagnostic signal — name, message, code and method", () => {
+    const result = toLogSafeError(axiosError());
+
+    expect(result).toContain("AxiosError");
+    expect(result).toContain("timeout of 23000ms exceeded");
+    expect(result).toContain("ECONNABORTED");
+    expect(result).toContain("GET");
+    expect(result).toContain("api.scraperapi.com");
+  });
+
+  it("includes the HTTP status when the upstream answered", () => {
+    const error = new Error("Request failed with status code 403") as Error & {
+      response: { status: number };
+    };
+    error.response = { status: 403 };
+
+    expect(toLogSafeError(error)).toContain("403");
+  });
+
+  it("does not dump the raw request/socket internals", () => {
+    const result = toLogSafeError(axiosError());
+
+    expect(result).not.toContain("_header");
+    expect(result).not.toContain("authorized");
+    expect(result).not.toContain("Referer");
+  });
+
+  it("stays on a single line", () => {
+    expect(toLogSafeError(axiosError())).not.toContain("\n");
+  });
+});
+
+describe("toLogSafeError — other shapes", () => {
+  it("formats a plain Error", () => {
+    const result = toLogSafeError(new Error("boom"));
+    expect(result).toBe("Error: boom");
+  });
+
+  it("redacts secrets embedded in a plain Error message", () => {
+    const result = toLogSafeError(
+      new Error("failed calling https://x.com/a?api_key=abcdef123456"),
+    );
+    expect(result).not.toContain("abcdef123456");
+  });
+
+  it("handles strings, null and undefined without throwing", () => {
+    expect(toLogSafeError("raw string")).toContain("raw string");
+    expect(() => toLogSafeError(null)).not.toThrow();
+    expect(() => toLogSafeError(undefined)).not.toThrow();
+  });
+
+  it("truncates an oversized message instead of flooding the log", () => {
+    const result = toLogSafeError(new Error("x".repeat(5000)));
+    expect(result.length).toBeLessThan(1000);
+  });
+});

--- a/src/platform/errors/index.ts
+++ b/src/platform/errors/index.ts
@@ -1,6 +1,6 @@
 /**
  * Categorizador de Errores
- * 
+ *
  * Categoriza automáticamente errores para determinar la estrategia de reintentos.
  * Tipos: JAVASCRIPT_REQUIRED, RATE_LIMITED, BLOCKING, NETWORK_ERROR, UNKNOWN
  */
@@ -9,14 +9,14 @@
  * Enumeración de tipos de error
  */
 export enum ErrorType {
-  JAVASCRIPT_REQUIRED = 'javascript_required',
-  RATE_LIMITED = 'rate_limited',
-  BLOCKING = 'blocking',
-  NETWORK_ERROR = 'network_error',
-  NOT_FOUND = 'not_found',
-  SERVER_ERROR = 'server_error',
-  TIMEOUT = 'timeout',
-  UNKNOWN = 'unknown',
+  JAVASCRIPT_REQUIRED = "javascript_required",
+  RATE_LIMITED = "rate_limited",
+  BLOCKING = "blocking",
+  NETWORK_ERROR = "network_error",
+  NOT_FOUND = "not_found",
+  SERVER_ERROR = "server_error",
+  TIMEOUT = "timeout",
+  UNKNOWN = "unknown",
 }
 
 /**
@@ -33,14 +33,14 @@ export interface CategorizedError {
 
 /**
  * Categoriza error HTTP por código de estado
- * 
+ *
  * @param statusCode Código de estado HTTP
  * @param retryAfter Valor opcional del header Retry-After (en segundos)
  * @returns Error categorizado
  */
 export function categorizeHttpError(
   statusCode: number,
-  retryAfter?: string
+  retryAfter?: string,
 ): CategorizedError {
   const retryDelay = retryAfter ? Number.parseInt(retryAfter, 10) : undefined;
 
@@ -50,7 +50,7 @@ export function categorizeHttpError(
       return {
         type: ErrorType.RATE_LIMITED,
         statusCode,
-        message: 'Demasiadas solicitudes (429) - Rate limited',
+        message: "Demasiadas solicitudes (429) - Rate limited",
         retriable: true,
         retryDelay,
       };
@@ -60,7 +60,7 @@ export function categorizeHttpError(
       return {
         type: ErrorType.BLOCKING,
         statusCode,
-        message: 'Prohibido (403) - La IP podría estar bloqueada',
+        message: "Prohibido (403) - La IP podría estar bloqueada",
         retriable: true,
         retryDelay,
       };
@@ -70,7 +70,7 @@ export function categorizeHttpError(
       return {
         type: ErrorType.NOT_FOUND,
         statusCode,
-        message: 'No encontrado (404) - El recurso no existe',
+        message: "No encontrado (404) - El recurso no existe",
         retriable: false,
       };
 
@@ -99,23 +99,23 @@ export function categorizeHttpError(
 
 /**
  * Categoriza error genérico
- * 
+ *
  * Detecta patrones de error comunes:
  * - Errores de red (ECONNREFUSED, ETIMEDOUT, ENOTFOUND)
  * - Errores de timeout
  * - Renderización de JavaScript requerida (contenido HTML pequeño)
- * 
+ *
  * @param error Objeto de error
  * @param htmlContent Contenido HTML opcional para verificar tamaño
  * @returns Error categorizado
  */
 export function categorizeError(
   error: unknown,
-  htmlContent?: string
+  htmlContent?: string,
 ): CategorizedError {
   if (!error) return categorizarNulo();
   if (error instanceof Error) return categorizarInstanciaError(error);
-  if (typeof error === 'string') return categorizarErrorString(error);
+  if (typeof error === "string") return categorizarErrorString(error);
   if (htmlContent) return categorizarHtml(htmlContent);
 
   return {
@@ -129,7 +129,7 @@ export function categorizeError(
 function categorizarNulo(): CategorizedError {
   return {
     type: ErrorType.UNKNOWN,
-    message: 'Error desconocido (null/undefined)',
+    message: "Error desconocido (null/undefined)",
     retriable: false,
   };
 }
@@ -137,46 +137,53 @@ function categorizarNulo(): CategorizedError {
 function categorizarInstanciaError(error: Error): CategorizedError {
   const message = error.message.toLowerCase();
 
-  if (message.includes('econnrefused') || message.includes('connect econnrefused')) {
+  if (
+    message.includes("econnrefused") ||
+    message.includes("connect econnrefused")
+  ) {
     return {
       type: ErrorType.NETWORK_ERROR,
-      message: 'Conexión rechazada - El servidor podría estar caído',
+      message: "Conexión rechazada - El servidor podría estar caído",
       retriable: true,
       details: { originalError: error.message },
     };
   }
 
-  if (message.includes('etimedout') || message.includes('timeout') || message.includes('timed out')) {
+  if (
+    message.includes("etimedout") ||
+    message.includes("timeout") ||
+    message.includes("timed out")
+  ) {
     return {
       type: ErrorType.TIMEOUT,
-      message: 'Timeout de solicitud - El servidor no está respondiendo',
+      message: "Timeout de solicitud - El servidor no está respondiendo",
       retriable: true,
       details: { originalError: error.message },
     };
   }
 
-  if (message.includes('enotfound') || message.includes('getaddrinfo')) {
+  if (message.includes("enotfound") || message.includes("getaddrinfo")) {
     return {
       type: ErrorType.NETWORK_ERROR,
-      message: 'Error de búsqueda DNS - Dominio no encontrado',
+      message: "Error de búsqueda DNS - Dominio no encontrado",
       retriable: true,
       details: { originalError: error.message },
     };
   }
 
-  if (message.includes('econnreset')) {
+  if (message.includes("econnreset")) {
     return {
       type: ErrorType.NETWORK_ERROR,
-      message: 'Conexión reiniciada - El servidor cerró la conexión',
+      message: "Conexión reiniciada - El servidor cerró la conexión",
       retriable: true,
       details: { originalError: error.message },
     };
   }
 
-  if (message.includes('javascript') || message.includes('content too small')) {
+  if (message.includes("javascript") || message.includes("content too small")) {
     return {
       type: ErrorType.JAVASCRIPT_REQUIRED,
-      message: 'El contenido requiere renderización de JavaScript',
+      message: "El contenido requiere renderización de JavaScript",
       retriable: true,
       details: { originalError: error.message },
     };
@@ -194,10 +201,10 @@ function categorizarInstanciaError(error: Error): CategorizedError {
 function categorizarErrorString(error: string): CategorizedError {
   const lower = error.toLowerCase();
 
-  if (lower.includes('timeout')) {
+  if (lower.includes("timeout")) {
     return { type: ErrorType.TIMEOUT, message: error, retriable: true };
   }
-  if (lower.includes('connection') || lower.includes('network')) {
+  if (lower.includes("connection") || lower.includes("network")) {
     return { type: ErrorType.NETWORK_ERROR, message: error, retriable: true };
   }
   return { type: ErrorType.UNKNOWN, message: error, retriable: false };
@@ -206,14 +213,14 @@ function categorizarErrorString(error: string): CategorizedError {
 function categorizarHtml(htmlContent: string): CategorizedError {
   const esJsRequerido =
     htmlContent.length < 1000 &&
-    (htmlContent.includes('javascript') ||
-      htmlContent.includes('enable javascript') ||
-      htmlContent.includes('script is required'));
+    (htmlContent.includes("javascript") ||
+      htmlContent.includes("enable javascript") ||
+      htmlContent.includes("script is required"));
 
   if (esJsRequerido) {
     return {
       type: ErrorType.JAVASCRIPT_REQUIRED,
-      message: 'Contenido requiere JavaScript - HTML muy pequeño',
+      message: "Contenido requiere JavaScript - HTML muy pequeño",
       retriable: true,
       details: { contentLength: htmlContent.length },
     };
@@ -221,14 +228,14 @@ function categorizarHtml(htmlContent: string): CategorizedError {
 
   return {
     type: ErrorType.UNKNOWN,
-    message: 'Error desconocido en contenido HTML',
+    message: "Error desconocido en contenido HTML",
     retriable: false,
   };
 }
 
 /**
  * Verifica si un error es recuperable basado en el tipo
- * 
+ *
  * @param errorType Tipo de error
  * @returns Si el error debería reintentarse
  */
@@ -245,10 +252,10 @@ export function isRetriable(errorType: ErrorType): boolean {
 
 /**
  * Obtiene el delay de reintentos para el tipo de error
- * 
+ *
  * Algunos errores tienen delays recomendados de servidores (header Retry-After).
  * Esta función proporciona defaults sensatos.
- * 
+ *
  * @param error Error categorizado
  * @returns Delay en milisegundos (o undefined si no hay delay especificado por servidor)
  */
@@ -274,6 +281,8 @@ export function getRetryDelay(error: CategorizedError): number | undefined {
   }
 }
 
+export { redactSecrets, toLogSafeError, REDACTED } from "./log-safe";
+
 export interface PublicError {
   error: string;
   stack?: string;
@@ -282,6 +291,7 @@ export interface PublicError {
 export function redactError(error: unknown, env?: string): PublicError {
   const isProd = (env ?? process.env.NODE_ENV) === "production";
   if (isProd) return { error: "Internal Server Error" };
-  if (error instanceof Error) return { error: error.message, stack: error.stack };
+  if (error instanceof Error)
+    return { error: error.message, stack: error.stack };
   return { error: String(error ?? "Unknown error") };
 }

--- a/src/platform/errors/log-safe.ts
+++ b/src/platform/errors/log-safe.ts
@@ -1,0 +1,106 @@
+/**
+ * Redacción de secretos para logs.
+ *
+ * Distinto de `redactError`, que arma el body de una respuesta HTTP y en
+ * producción devuelve un mensaje genérico. Acá el objetivo es el opuesto:
+ * conservar el diagnóstico (nombre, mensaje, código, status, URL) y tapar
+ * únicamente los secretos.
+ *
+ * Motivo: ScraperAPI exige la API key como query param, así que viaja dentro
+ * de `config.url` de axios. Loguear el error crudo la publicaba en texto plano
+ * en los logs de runtime.
+ */
+
+export const REDACTED = "***REDACTED***";
+
+/** Nombres de query params cuyo valor nunca debe aparecer en un log. */
+const SENSITIVE_PARAM =
+  /(api[-_]?key|access[-_]?token|refresh[-_]?token|client[-_]?secret|authorization|password|passwd|signature|secret|token|auth|sig|pwd|key)/i;
+
+/** Env vars cuyo nombre sugiere que el valor es un secreto. */
+const SECRET_ENV_NAME = /(KEY|SECRET|TOKEN|PASSWORD|PASSWD|CREDENTIAL)/i;
+
+/**
+ * Valores más cortos que esto se ignoran: enmascarar cadenas de 3 o 4
+ * caracteres arruinaría el log entero por coincidencias accidentales.
+ */
+const MIN_SECRET_LENGTH = 8;
+
+const MAX_MESSAGE_LENGTH = 300;
+const MAX_URL_LENGTH = 200;
+
+function truncate(value: string, max: number): string {
+  return value.length > max ? `${value.slice(0, max)}…` : value;
+}
+
+function secretEnvValues(): string[] {
+  return Object.entries(process.env)
+    .filter(
+      ([name, value]) =>
+        SECRET_ENV_NAME.test(name) &&
+        typeof value === "string" &&
+        value.length >= MIN_SECRET_LENGTH,
+    )
+    .map(([, value]) => value as string);
+}
+
+/**
+ * Enmascara secretos en un texto arbitrario: valores de query params sensibles
+ * y valores de env vars que parezcan secretas, aparezcan donde aparezcan.
+ */
+export function redactSecrets(input: string): string {
+  let output = input.replace(
+    /([?&#][^?&#=\s]*?)=([^&\s"']*)/g,
+    (match, rawName: string, value: string) => {
+      const name = rawName.slice(1);
+      if (!value || !SENSITIVE_PARAM.test(name)) return match;
+      return `${rawName}=${REDACTED}`;
+    },
+  );
+
+  for (const secret of secretEnvValues()) {
+    output = output.split(secret).join(REDACTED);
+  }
+
+  return output;
+}
+
+interface HttpErrorShape {
+  code?: unknown;
+  config?: { url?: unknown; method?: unknown };
+  response?: { status?: unknown };
+}
+
+function asHttpErrorShape(error: unknown): HttpErrorShape {
+  return typeof error === "object" && error !== null
+    ? (error as HttpErrorShape)
+    : {};
+}
+
+/**
+ * Devuelve un resumen de una línea, sin secretos y sin el volcado completo del
+ * objeto de axios (que llegaba a ocupar cientos de líneas por error).
+ */
+export function toLogSafeError(error: unknown): string {
+  const parts: string[] = [];
+
+  if (error instanceof Error) {
+    parts.push(`${error.name}: ${truncate(error.message, MAX_MESSAGE_LENGTH)}`);
+  } else {
+    parts.push(truncate(String(error ?? "Unknown error"), MAX_MESSAGE_LENGTH));
+  }
+
+  const { code, config, response } = asHttpErrorShape(error);
+
+  if (typeof code === "string" && code) parts.push(`code=${code}`);
+  if (typeof response?.status === "number")
+    parts.push(`status=${response.status}`);
+
+  if (typeof config?.url === "string" && config.url) {
+    const method =
+      typeof config.method === "string" ? config.method.toUpperCase() : "GET";
+    parts.push(`${method} ${truncate(config.url, MAX_URL_LENGTH)}`);
+  }
+
+  return redactSecrets(parts.join(" | ").replace(/\s*\n\s*/g, " "));
+}

--- a/src/platform/vtex/helpers.ts
+++ b/src/platform/vtex/helpers.ts
@@ -3,6 +3,7 @@ import { vtexProduct } from "@/types/vtex-product";
 import { Product } from "@/types/product";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { httpClient } from "@/platform/http";
+import { toLogSafeError } from "@/platform/errors";
 
 export type VtexInstallment =
   vtexProduct["items"][number]["sellers"][number]["commertialOffer"]["Installments"][number];
@@ -45,9 +46,7 @@ export const NON_ELECTRONICS_PATTERN =
 
 export function isElectronicsProduct(product: vtexProduct): boolean {
   if (!product.categories?.length) return true;
-  return !product.categories.some((cat) =>
-    NON_ELECTRONICS_PATTERN.test(cat),
-  );
+  return !product.categories.some((cat) => NON_ELECTRONICS_PATTERN.test(cat));
 }
 
 /**
@@ -93,10 +92,11 @@ export function createVtexScraper(
         .filter(isElectronicsProduct)
         .map((p: vtexProduct) => formatVtexProduct(p, storeName, domain));
     } catch (error) {
-      console.error(`[${storeName}] Error al obtener productos:`, error);
+      console.error(
+        `[${storeName}] Error al obtener productos:`,
+        toLogSafeError(error),
+      );
       return [];
     }
   };
 }
-
-

--- a/src/scrapers/carrefour/index.ts
+++ b/src/scrapers/carrefour/index.ts
@@ -10,6 +10,7 @@ import {
 } from "@/platform/vtex/helpers";
 import { httpClient } from "@/platform/http";
 import { sanitizeUrl } from "@/platform/url";
+import { toLogSafeError } from "@/platform/errors";
 
 const USER_AGENT =
   "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36";
@@ -51,9 +52,9 @@ function extractFromApolloCache(html: string): Product[] {
 
       let imageUrl = "";
       for (let i = 0; i < 3; i++) {
-        const item = cache[
-          `${key}.items({"filter":"ALL_AVAILABLE"}).${i}`
-        ] as { images?: Array<{ id?: string }> } | undefined;
+        const item = cache[`${key}.items({"filter":"ALL_AVAILABLE"}).${i}`] as
+          | { images?: Array<{ id?: string }> }
+          | undefined;
         if (!item) break;
         const imgRef = item.images?.[0]?.id;
         if (imgRef) {
@@ -88,7 +89,12 @@ const formatProductCarrefour = (product: vtexProduct): Product => {
   const sellers = product.items?.[0]?.sellers ?? [];
   const defaultSeller = sellers.find((s) => s.sellerDefault);
   const installments = defaultSeller?.commertialOffer?.Installments ?? [];
-  return formatVtexProduct(product, StoreNamesEnum.CARREFOUR, DOMAIN, installments);
+  return formatVtexProduct(
+    product,
+    StoreNamesEnum.CARREFOUR,
+    DOMAIN,
+    installments,
+  );
 };
 
 export async function scrapeCarrefour(query: string): Promise<Product[]> {
@@ -109,12 +115,15 @@ export async function scrapeCarrefour(query: string): Promise<Product[]> {
     if (data?.redirect) {
       try {
         const redirect: string = data.redirect;
-        const resolvedUrl = redirect.startsWith('/')
+        const resolvedUrl = redirect.startsWith("/")
           ? `https://www.carrefour.com.ar${redirect}`
           : redirect;
         sanitizeUrl(resolvedUrl);
-        if (new URL(resolvedUrl).origin !== 'https://www.carrefour.com.ar') {
-          console.warn('[carrefour] Redirect origin mismatch, skipping:', resolvedUrl);
+        if (new URL(resolvedUrl).origin !== "https://www.carrefour.com.ar") {
+          console.warn(
+            "[carrefour] Redirect origin mismatch, skipping:",
+            resolvedUrl,
+          );
           return [];
         }
         const { data: html } = await httpClient.get<string>(resolvedUrl, {
@@ -126,14 +135,17 @@ export async function scrapeCarrefour(query: string): Promise<Product[]> {
         });
         return extractFromApolloCache(html);
       } catch {
-        console.warn('[carrefour] Redirect blocked:', data.redirect);
+        console.warn("[carrefour] Redirect blocked:", data.redirect);
         return [];
       }
     }
 
     return [];
   } catch (error) {
-    console.error("Error fetching products from Carrefour:", error);
+    console.error(
+      "Error fetching products from Carrefour:",
+      toLogSafeError(error),
+    );
     return [];
   }
 }

--- a/src/scrapers/fravega/__tests__/fravega.test.ts
+++ b/src/scrapers/fravega/__tests__/fravega.test.ts
@@ -1,0 +1,70 @@
+import { scrapeFravega } from "@/scrapers/fravega";
+
+jest.mock("@/platform/http", () => ({
+  httpClient: {
+    get: jest.fn(),
+  },
+}));
+
+import { httpClient } from "@/platform/http";
+
+const mockGet = httpClient.get as jest.Mock;
+
+const API_KEY = "10c72dd259391bcada437333574ed519";
+
+/** Reproduce the axios error shape that leaked the key into production logs. */
+const timeoutErrorCarryingTheKey = () => {
+  const error = new Error("timeout of 23000ms exceeded") as Error & {
+    code: string;
+    config: { url: string; method: string };
+  };
+  error.name = "AxiosError";
+  error.code = "ECONNABORTED";
+  error.config = {
+    url: `https://api.scraperapi.com?api_key=${API_KEY}&url=https%3A%2F%2Fwww.fravega.com%2Fl%2F%3Fkeyword%3Dtv`,
+    method: "get",
+  };
+  return error;
+};
+
+describe("scrapeFravega — error logging", () => {
+  const originalEnv = process.env;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, SCRAPER_API_KEY: API_KEY };
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    errorSpy.mockRestore();
+  });
+
+  it("never writes the ScraperAPI key to the log when the request fails", async () => {
+    mockGet.mockRejectedValue(timeoutErrorCarryingTheKey());
+
+    await scrapeFravega("tv");
+
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).not.toContain(API_KEY);
+  });
+
+  it("still logs enough to diagnose the failure", async () => {
+    mockGet.mockRejectedValue(timeoutErrorCarryingTheKey());
+
+    await scrapeFravega("tv");
+
+    const logged = errorSpy.mock.calls.flat().join(" ");
+    expect(logged).toContain("Fravega");
+    expect(logged).toContain("timeout of 23000ms exceeded");
+    expect(logged).toContain("ECONNABORTED");
+  });
+
+  it("returns an empty array so the per-store fallback still applies", async () => {
+    mockGet.mockRejectedValue(timeoutErrorCarryingTheKey());
+
+    await expect(scrapeFravega("tv")).resolves.toEqual([]);
+  });
+});

--- a/src/scrapers/fravega/index.ts
+++ b/src/scrapers/fravega/index.ts
@@ -3,6 +3,7 @@ import { capitalize } from "@/lib/capitalize";
 import { Product } from "@/types/product";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { httpClient } from "@/platform/http";
+import { toLogSafeError } from "@/platform/errors";
 
 interface FravegaNextProduct {
   id?: string;
@@ -22,9 +23,7 @@ interface FravegaNextData {
 }
 
 /** Extrae el mapa id→brand desde el JSON __NEXT_DATA__ embebido por Next.js en el HTML. */
-function extraerMarcasDesdeNextData(
-  html: string,
-): Map<string, string> {
+function extraerMarcasDesdeNextData(html: string): Map<string, string> {
   const marcasPorId = new Map<string, string>();
   try {
     const $ = load(html);
@@ -81,15 +80,11 @@ export async function scrapeFravega(query: string): Promise<Product[]> {
           $(item).find("img[src*='images.fravega.com/f300/']").attr("src") ??
           "https://placehold.co/300x200";
         const relativeUrl =
-          $(item)
-            .find("a[rel='bookmark'][href^='/p/']")
-            .first()
-            .attr("href") ?? "";
+          $(item).find("a[rel='bookmark'][href^='/p/']").first().attr("href") ??
+          "";
         // El id del producto está en la URL: /p/{id}-...
         const productId = relativeUrl.split("/p/")[1]?.split("-")[0] ?? "";
-        const brand = capitalize(
-          marcasPorId.get(productId) ?? "Unknown",
-        );
+        const brand = capitalize(marcasPorId.get(productId) ?? "Unknown");
 
         if (!name) return null;
         return {
@@ -106,7 +101,10 @@ export async function scrapeFravega(query: string): Promise<Product[]> {
 
     return products;
   } catch (error) {
-    console.error("Error fetching products from Fravega:", error);
+    console.error(
+      "Error fetching products from Fravega:",
+      toLogSafeError(error),
+    );
     return [];
   }
 }

--- a/src/scrapers/mercadolibre/index.ts
+++ b/src/scrapers/mercadolibre/index.ts
@@ -2,6 +2,7 @@ import { capitalize } from "@/lib/capitalize";
 import { Product } from "@/types/product";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { httpClient } from "@/platform/http";
+import { toLogSafeError } from "@/platform/errors";
 
 interface MeliAttribute {
   id: string;
@@ -38,7 +39,10 @@ export async function scrapeMercadoLibre(query: string): Promise<Product[]> {
       };
     });
   } catch (error) {
-    console.error("Error fetching products from MercadoLibre:", error);
+    console.error(
+      "Error fetching products from MercadoLibre:",
+      toLogSafeError(error),
+    );
     return [];
   }
 }


### PR DESCRIPTION
## Problem

The ScraperAPI key (`SCRAPER_API_KEY`) was written **in plaintext to Vercel production runtime logs**.

ScraperAPI requires the key as a query parameter — there is no header option — so it travels inside the axios `config.url`:

```
url: 'https://api.scraperapi.com?api_key=10c72…4ed519&url=https%3A%2F%2Fwww.fravega.com%2Fl%2F%3Fkeyword%3Dsamsung%252065'
```

`src/scrapers/fravega/index.ts:109` did `console.error("...", error)`, dumping the whole axios error object — `config.url` included. The key was never logged on purpose; it rode along inside the error.

Anyone with read access to the project's runtime logs could read it.

## Why not `redactError`

`redactError` builds an **HTTP response body** and returns `{ error: "Internal Server Error" }` in production. Using it for logs would turn every scraper failure into that same constant string and destroy all diagnostic value. Wrong tool: a leak traded for blindness.

## Approach

New `src/platform/errors/log-safe.ts` with the opposite goal — keep the diagnostics, mask only the secrets.

**`redactSecrets(input)`**
- Masks the value of sensitive query parameters: `api_key`, `access_token`, `token`, `client_secret`, `password`, `authorization`, `signature`, … (case-insensitive, all occurrences).
- Masks the value of any env var whose *name* looks secret (`KEY|SECRET|TOKEN|PASSWORD|PASSWD|CREDENTIAL`) wherever it appears in the text — so a secret leaking through a path segment or a free-text message is caught too. This auto-covers env vars added later.
- Ignores values under 8 characters, otherwise a `SOME_KEY=dev` would mask every `dev` in the log.

**`toLogSafeError(error)`**
- Returns a single redacted line: `name: message | code=… | status=… | METHOD url`.
- Drops the raw `request`/`socket` internals. Those dumps were producing ~1600 lines of log for two errors.
- Truncates message (300) and URL (200).

## Applied at every site that logs an error carrying an upstream HTTP request

| File | Line |
|---|---|
| `scrapers/fravega/index.ts` | 109 |
| `scrapers/mercadolibre/index.ts` | 41 |
| `scrapers/carrefour/index.ts` | 136 |
| `platform/vtex/helpers.ts` | 96 |
| `features/price-search/service.ts` | 56 |
| `app/api/scrape/route.ts` | 40 |

## Tests

TDD — written failing first.

- `platform/errors/__tests__/log-safe.test.ts` — 18 cases: the exact Fravega URL that leaked, the usual secret param names, case-insensitivity, multiple occurrences, env-value masking, short-value guard, non-secret params preserved, axios shape formatting, no raw internals, single line, truncation, null/undefined safety.
- `scrapers/fravega/__tests__/fravega.test.ts` — new regression suite driving `scrapeFravega` through a real failure with `SCRAPER_API_KEY` set, asserting the key never reaches `console.error` while the message and `ECONNABORTED` still do.

`npm test` → 44 suites, 292 tests passing. `npm run lint` clean (one pre-existing warning in `e2e/happy-path.spec.ts`). `npm run build` succeeds.

## Also

Documents `SCRAPER_API_KEY` in the README env table, where it was missing.

## ⚠️ Still required after merge

**The exposed key must be rotated** — ScraperAPI dashboard → regenerate → update in Vercel (Settings → Environment Variables → Production) → redeploy. This PR only stops the *next* key from leaking; it cannot un-log the current one.

## Related

Independent of #132 (search validation and error propagation). Both branch from `master`; no overlapping files.