### PR TITLE
fix(scrapers): propagate failures to backoff instead of swallowing them

### DIFF
--- a/src/features/price-search/__tests__/router.test.ts
+++ b/src/features/price-search/__tests__/router.test.ts
@@ -1,47 +1,51 @@
-import { scrapeWithFallback } from '../router';
-import { exponentialBackoff } from '@/platform/backoff';
-import { getCachedData } from '@/platform/cache';
-import { Product } from '@/types/product';
+import { scrapeWithFallback, STORE_RETRY_BUDGET_MS } from "../router";
+import { exponentialBackoff } from "@/platform/backoff";
+import { getCachedData } from "@/platform/cache";
+import { Product } from "@/types/product";
 
-jest.mock('@/platform/backoff');
-jest.mock('@/platform/cache', () => ({
-  ...jest.requireActual('@/platform/cache'),
+jest.mock("@/platform/backoff");
+jest.mock("@/platform/cache", () => ({
+  ...jest.requireActual("@/platform/cache"),
   getCachedData: jest.fn(),
   setCachedData: jest.fn(),
   setStoreCacheNX: jest.fn(),
 }));
 
-const mockExponentialBackoff = exponentialBackoff as jest.MockedFunction<typeof exponentialBackoff>;
-const mockGetCachedData = getCachedData as jest.MockedFunction<typeof getCachedData>;
+const mockExponentialBackoff = exponentialBackoff as jest.MockedFunction<
+  typeof exponentialBackoff
+>;
+const mockGetCachedData = getCachedData as jest.MockedFunction<
+  typeof getCachedData
+>;
 
 const sampleProduct: Product = {
   name: 'TV Samsung 55"',
   price: 100000,
-  url: 'https://tienda.com/tv',
-  image: 'https://tienda.com/tv.jpg',
-  brand: 'Samsung',
+  url: "https://tienda.com/tv",
+  image: "https://tienda.com/tv.jpg",
+  brand: "Samsung",
   installment: 12,
-  from: 'naldo' as Product['from'],
+  from: "naldo" as Product["from"],
 };
 
 const cachedProduct: Product = {
   name: 'TV LG 55" (caché)',
   price: 95000,
-  url: 'https://tienda.com/tv-lg',
-  image: 'https://tienda.com/tv-lg.jpg',
-  brand: 'LG',
+  url: "https://tienda.com/tv-lg",
+  image: "https://tienda.com/tv-lg.jpg",
+  brand: "LG",
   installment: 6,
-  from: 'naldo' as Product['from'],
+  from: "naldo" as Product["from"],
 };
 
-describe('scrapeWithFallback', () => {
+describe("scrapeWithFallback", () => {
   const mockScraper = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('devuelve productos si primaryScraper tiene éxito en primer intento', async () => {
+  it("devuelve productos si primaryScraper tiene éxito en primer intento", async () => {
     mockExponentialBackoff.mockResolvedValueOnce({
       success: true,
       data: [sampleProduct],
@@ -49,12 +53,29 @@ describe('scrapeWithFallback', () => {
       totalTime: 10,
     });
 
-    const result = await scrapeWithFallback('naldo', 'tv', mockScraper);
+    const result = await scrapeWithFallback("naldo", "tv", mockScraper);
 
     expect(result).toEqual([sampleProduct]);
   });
 
-  it('reintenta y tiene éxito en el segundo intento', async () => {
+  it("acota los reintentos con un presupuesto de tiempo por tienda", async () => {
+    mockExponentialBackoff.mockResolvedValueOnce({
+      success: true,
+      data: [sampleProduct],
+      attempts: 1,
+      totalTime: 10,
+    });
+
+    await scrapeWithFallback("naldo", "tv", mockScraper);
+
+    expect(mockExponentialBackoff).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({ maxTotalTime: STORE_RETRY_BUDGET_MS }),
+    );
+    expect(STORE_RETRY_BUDGET_MS).toBeLessThanOrEqual(15_000);
+  });
+
+  it("reintenta y tiene éxito en el segundo intento", async () => {
     mockExponentialBackoff.mockResolvedValueOnce({
       success: true,
       data: [sampleProduct],
@@ -62,42 +83,46 @@ describe('scrapeWithFallback', () => {
       totalTime: 2500,
     });
 
-    const result = await scrapeWithFallback('naldo', 'tv', mockScraper);
+    const result = await scrapeWithFallback("naldo", "tv", mockScraper);
 
     expect(result).toEqual([sampleProduct]);
   });
 
-  it('devuelve caché cuando todos los intentos fallan (cache hit)', async () => {
+  it("devuelve caché cuando todos los intentos fallan (cache hit)", async () => {
     mockExponentialBackoff.mockResolvedValueOnce({
       success: false,
-      error: new Error('conexión rechazada'),
+      error: new Error("conexión rechazada"),
       attempts: 4,
       totalTime: 8000,
     });
     mockGetCachedData.mockResolvedValueOnce([cachedProduct]);
 
-    const result = await scrapeWithFallback('naldo', 'tv', mockScraper);
+    const result = await scrapeWithFallback("naldo", "tv", mockScraper);
 
     expect(result).toEqual([cachedProduct]);
-    expect(mockGetCachedData).toHaveBeenCalledWith('s:naldo:a46e5d2bbe2d3b05b2d28b6054d98c18046bce28893d04e050724168116d5587');
+    expect(mockGetCachedData).toHaveBeenCalledWith(
+      "s:naldo:a46e5d2bbe2d3b05b2d28b6054d98c18046bce28893d04e050724168116d5587",
+    );
   });
 
-  it('devuelve [] cuando todos los intentos fallan y caché es null (cache miss)', async () => {
+  it("devuelve [] cuando todos los intentos fallan y caché es null (cache miss)", async () => {
     mockExponentialBackoff.mockResolvedValueOnce({
       success: false,
-      error: new Error('timeout'),
+      error: new Error("timeout"),
       attempts: 4,
       totalTime: 8000,
     });
     mockGetCachedData.mockResolvedValueOnce(null);
 
-    const result = await scrapeWithFallback('naldo', 'tv', mockScraper);
+    const result = await scrapeWithFallback("naldo", "tv", mockScraper);
 
     expect(result).toEqual([]);
   });
 
-  it('NO llama setCachedData (las escrituras se delegan al pipeline de service.ts)', async () => {
-    const { setCachedData } = jest.requireMock('@/platform/cache') as { setCachedData: jest.Mock };
+  it("NO llama setCachedData (las escrituras se delegan al pipeline de service.ts)", async () => {
+    const { setCachedData } = jest.requireMock("@/platform/cache") as {
+      setCachedData: jest.Mock;
+    };
 
     mockExponentialBackoff.mockResolvedValueOnce({
       success: true,
@@ -106,23 +131,25 @@ describe('scrapeWithFallback', () => {
       totalTime: 10,
     });
 
-    await scrapeWithFallback('naldo', 'tv', mockScraper);
+    await scrapeWithFallback("naldo", "tv", mockScraper);
 
     expect(setCachedData).not.toHaveBeenCalled();
   });
 
-  it('NO llama setCachedData si se devuelve resultado de caché', async () => {
-    const { setCachedData } = jest.requireMock('@/platform/cache') as { setCachedData: jest.Mock };
+  it("NO llama setCachedData si se devuelve resultado de caché", async () => {
+    const { setCachedData } = jest.requireMock("@/platform/cache") as {
+      setCachedData: jest.Mock;
+    };
 
     mockExponentialBackoff.mockResolvedValueOnce({
       success: false,
-      error: new Error('fallo'),
+      error: new Error("fallo"),
       attempts: 4,
       totalTime: 8000,
     });
     mockGetCachedData.mockResolvedValueOnce([cachedProduct]);
 
-    await scrapeWithFallback('naldo', 'tv', mockScraper);
+    await scrapeWithFallback("naldo", "tv", mockScraper);
 
     expect(setCachedData).not.toHaveBeenCalled();
   });

--- a/src/features/price-search/router.ts
+++ b/src/features/price-search/router.ts
@@ -1,6 +1,18 @@
-import { exponentialBackoff } from '@/platform/backoff';
-import { getCachedData, cacheKey } from '@/platform/cache';
-import { Product } from '@/types/product';
+import { exponentialBackoff } from "@/platform/backoff";
+import { getCachedData, cacheKey } from "@/platform/cache";
+import { Product } from "@/types/product";
+
+/**
+ * Presupuesto de reintentos por tienda.
+ *
+ * Las tiendas se consultan en paralelo, así que la latencia de /api/scrape la
+ * marca la más lenta. Sin este tope, un 403 permanente como el de MercadoLibre
+ * consumiría los 4 reintentos (2s+4s+8s+16s) sin ninguna chance de éxito.
+ *
+ * No acota el primer intento: un request ya en vuelo no se puede interrumpir
+ * desde acá — ese límite es el timeout de `platform/http`.
+ */
+export const STORE_RETRY_BUDGET_MS = 10_000;
 
 /**
  * Envuelve un scraper con exponential backoff + caché de respaldo por tienda.
@@ -12,14 +24,20 @@ export async function scrapeWithFallback(
   query: string,
   primaryScraper: (q: string) => Promise<Product[]>,
 ): Promise<Product[]> {
-  const result = await exponentialBackoff(() => primaryScraper(query));
+  const result = await exponentialBackoff(() => primaryScraper(query), {
+    maxTotalTime: STORE_RETRY_BUDGET_MS,
+  });
 
   if (result.success && result.data !== undefined) {
-    console.log(`[Router] store=${store} attempt=${result.attempts} outcome=success`);
+    console.log(
+      `[Router] store=${store} attempt=${result.attempts} outcome=success`,
+    );
     return result.data;
   }
 
-  console.log(`[Router] store=${store} attempt=${result.attempts} outcome=retry_exhausted`);
+  console.log(
+    `[Router] store=${store} attempt=${result.attempts} outcome=retry_exhausted`,
+  );
 
   const key = cacheKey.store(store, query);
   const cached = await getCachedData(key);

--- a/src/platform/backoff/__tests__/backoff.test.ts
+++ b/src/platform/backoff/__tests__/backoff.test.ts
@@ -1,24 +1,24 @@
-import { exponentialBackoff } from '@/platform/backoff';
+import { exponentialBackoff } from "@/platform/backoff";
 
-describe('Estrategia de Backoff', () => {
-  describe('exponentialBackoff', () => {
-    it('debería tener éxito en el primer intento', async () => {
-      const mockFn = jest.fn().mockResolvedValueOnce('éxito');
+describe("Estrategia de Backoff", () => {
+  describe("exponentialBackoff", () => {
+    it("debería tener éxito en el primer intento", async () => {
+      const mockFn = jest.fn().mockResolvedValueOnce("éxito");
 
       const result = await exponentialBackoff(mockFn, { maxAttempts: 3 });
 
       expect(result.success).toBe(true);
       expect(result.attempts).toBe(1);
-      expect(result.data).toBe('éxito');
+      expect(result.data).toBe("éxito");
       expect(mockFn).toHaveBeenCalledTimes(1);
     });
 
-    it('debería reintentar en caso de fallo', async () => {
+    it("debería reintentar en caso de fallo", async () => {
       const mockFn = jest
         .fn()
-        .mockRejectedValueOnce(new Error('Intento 1 falló'))
-        .mockRejectedValueOnce(new Error('Intento 2 falló'))
-        .mockResolvedValueOnce('éxito en el 3er intento');
+        .mockRejectedValueOnce(new Error("Intento 1 falló"))
+        .mockRejectedValueOnce(new Error("Intento 2 falló"))
+        .mockResolvedValueOnce("éxito en el 3er intento");
 
       const result = await exponentialBackoff(mockFn, {
         baseDelay: 10,
@@ -27,12 +27,12 @@ describe('Estrategia de Backoff', () => {
 
       expect(result.success).toBe(true);
       expect(result.attempts).toBe(3);
-      expect(result.data).toBe('éxito en el 3er intento');
+      expect(result.data).toBe("éxito en el 3er intento");
       expect(mockFn).toHaveBeenCalledTimes(3);
     });
 
-    it('debería fallar después del máximo de intentos', async () => {
-      const mockFn = jest.fn().mockRejectedValue(new Error('Siempre falla'));
+    it("debería fallar después del máximo de intentos", async () => {
+      const mockFn = jest.fn().mockRejectedValue(new Error("Siempre falla"));
 
       const result = await exponentialBackoff(mockFn, {
         baseDelay: 10,
@@ -42,15 +42,72 @@ describe('Estrategia de Backoff', () => {
       expect(result.success).toBe(false);
       expect(result.attempts).toBe(3);
       expect(result.error).toBeDefined();
-      expect(result.error?.message).toBe('Siempre falla');
+      expect(result.error?.message).toBe("Siempre falla");
       expect(mockFn).toHaveBeenCalledTimes(3);
     });
 
-    it('debería rastrear el tiempo total', async () => {
+    it("deja de reintentar cuando el próximo delay excedería el presupuesto", async () => {
+      const mockFn = jest.fn().mockRejectedValue(new Error("Siempre falla"));
+
+      const result = await exponentialBackoff(mockFn, {
+        baseDelay: 100,
+        maxAttempts: 4,
+        maxTotalTime: 150,
+        jitter: 0,
+      });
+
+      // Intento 1 falla, el delay de 100ms entra en presupuesto → intento 2.
+      // Tras el intento 2 el siguiente delay (200ms) excede los 150ms → corta.
+      expect(result.success).toBe(false);
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      expect(result.attempts).toBe(2);
+      expect(result.error?.message).toBe("Siempre falla");
+    });
+
+    it("no reintenta cuando el primer intento ya consumió el presupuesto", async () => {
+      const mockFn = jest.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        throw new Error("Timeout largo");
+      });
+
+      const result = await exponentialBackoff(mockFn, {
+        baseDelay: 10,
+        maxAttempts: 4,
+        maxTotalTime: 50,
+        jitter: 0,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(result.attempts).toBe(1);
+    });
+
+    it("el presupuesto no afecta a las llamadas que tienen éxito", async () => {
+      const mockFn = jest.fn().mockResolvedValue("éxito");
+
+      const result = await exponentialBackoff(mockFn, { maxTotalTime: 1 });
+
+      expect(result.success).toBe(true);
+      expect(result.data).toBe("éxito");
+    });
+
+    it("aplica un presupuesto por defecto sin configuración explícita", async () => {
+      const mockFn = jest.fn().mockRejectedValue(new Error("Siempre falla"));
+
+      const result = await exponentialBackoff(mockFn, {
+        baseDelay: 10,
+        maxAttempts: 2,
+      });
+
+      expect(result.success).toBe(false);
+      expect(mockFn).toHaveBeenCalledTimes(3);
+    });
+
+    it("debería rastrear el tiempo total", async () => {
       const mockFn = jest
         .fn()
-        .mockRejectedValueOnce(new Error('Fallo'))
-        .mockResolvedValueOnce('éxito');
+        .mockRejectedValueOnce(new Error("Fallo"))
+        .mockResolvedValueOnce("éxito");
 
       const result = await exponentialBackoff(mockFn, {
         baseDelay: 50,

--- a/src/platform/backoff/index.ts
+++ b/src/platform/backoff/index.ts
@@ -1,13 +1,13 @@
 /**
  * Estrategia de Exponential Backoff
- * 
+ *
  * Implementa exponential backoff con jitter para lógica de reintentos.
  * Estándar de la industria para manejar rate limiting y fallos transitorios.
- * 
+ *
  * Secuencia: 2s → 4s → 8s → 16s (con jitter aleatorio de 0-1s)
  */
 
-import { categorizeError, categorizeHttpError } from '@/platform/errors';
+import { categorizeError, categorizeHttpError } from "@/platform/errors";
 /**
  * Configuración para exponential backoff
  */
@@ -16,6 +16,22 @@ export interface BackoffConfig {
   maxDelay: number; // Tope máximo de delay (default: 64000ms = 64s)
   maxAttempts: number; // Número máximo de reintentos (default: 4)
   multiplier: number; // Multiplicador exponencial (default: 2x)
+  /**
+   * Presupuesto total de tiempo en milisegundos (default: 25000ms = 25s).
+   *
+   * `maxAttempts` por sí solo no acota la duración: un scraper con timeout de
+   * 23s reintentado 4 veces bloquearía la request más de dos minutos. Antes de
+   * cada espera se verifica si el próximo delay cabe en el presupuesto; si no
+   * cabe, se corta y el llamador pasa a su fallback.
+   */
+  maxTotalTime: number;
+  /**
+   * Jitter máximo en milisegundos (default: 1000ms).
+   *
+   * Configurable para que los tests puedan fijarlo en 0 y verificar el
+   * presupuesto de forma determinista.
+   */
+  jitter: number;
 }
 
 /**
@@ -31,21 +47,22 @@ export interface RetryResult<T> {
 
 /**
  * Calcula el delay para el siguiente intento con exponential backoff y jitter
- * 
+ *
  * Fórmula: min(baseDelay * (multiplier ^ attempt), maxDelay) + jitter
- * 
+ *
  * @param attempt Número de intento actual (indexado desde 0)
  * @param config Configuración de backoff
  * @returns Delay en milisegundos
  */
 function calculateDelay(
   attempt: number,
-  config: Partial<BackoffConfig> = {}
+  config: Partial<BackoffConfig> = {},
 ): number {
   const {
     baseDelay = 2000,
     maxDelay = 64000,
     multiplier = 2,
+    jitter = 1000,
   } = config;
 
   // Cálculo exponencial: baseDelay * (multiplier ^ attempt)
@@ -54,10 +71,10 @@ function calculateDelay(
   // Limitar a maxDelay
   const cappedDelay = Math.min(exponentialDelay, maxDelay);
 
-  // Añadir jitter aleatorio (0-1000ms) para evitar thundering herd
-  const jitter = Math.random() * 1000;
+  // Añadir jitter aleatorio para evitar thundering herd
+  const jitterMs = Math.random() * jitter;
 
-  return Math.round(cappedDelay + jitter);
+  return Math.round(cappedDelay + jitterMs);
 }
 
 /** Determina la categoría del error según su tipo (HTTP o genérico). */
@@ -68,7 +85,7 @@ function categorizarError(error: unknown): ReturnType<typeof categorizeError> {
   if (axiosLike?.response?.status) {
     return categorizeHttpError(
       axiosLike.response.status,
-      axiosLike.response.headers?.['retry-after'],
+      axiosLike.response.headers?.["retry-after"],
     );
   }
   return categorizeError(error);
@@ -78,7 +95,12 @@ function categorizarError(error: unknown): ReturnType<typeof categorizeError> {
 function resolverDelay(
   categorized: ReturnType<typeof categorizeError>,
   attempt: number,
-  config: { baseDelay: number; maxDelay: number; multiplier: number },
+  config: {
+    baseDelay: number;
+    maxDelay: number;
+    multiplier: number;
+    jitter: number;
+  },
 ): number {
   if (categorized.retryDelay !== undefined) {
     return categorized.retryDelay * 1000;
@@ -88,23 +110,25 @@ function resolverDelay(
 
 /**
  * Ejecuta una función con reintentos usando exponential backoff
- * 
+ *
  * Automáticamente reintenta en caso de fallo con delays incrementales.
  * Devuelve información detallada sobre intentos y tiempos.
- * 
+ *
  * @param fn Función a ejecutar (debe lanzar excepción en caso de fallo)
  * @param config Configuración de backoff (opcional)
  * @returns RetryResult con estado de éxito y datos
  */
 export async function exponentialBackoff<T>(
   fn: () => Promise<T>,
-  config: Partial<BackoffConfig> = {}
+  config: Partial<BackoffConfig> = {},
 ): Promise<RetryResult<T>> {
   const {
     baseDelay = 2000,
     maxDelay = 64000,
     maxAttempts = 4,
     multiplier = 2,
+    maxTotalTime = 25000,
+    jitter = 1000,
   } = config;
 
   let lastError: Error | undefined;
@@ -118,7 +142,7 @@ export async function exponentialBackoff<T>(
 
       const totalTime = Date.now() - startTime;
       console.log(
-        `[Backoff] ✅ Éxito en intento ${attempt + 1}/${maxAttempts + 1} (${totalTime}ms)`
+        `[Backoff] ✅ Éxito en intento ${attempt + 1}/${maxAttempts + 1} (${totalTime}ms)`,
       );
 
       return {
@@ -134,7 +158,28 @@ export async function exponentialBackoff<T>(
       if (categorized.retriable) {
         // Si tenemos reintentos restantes, esperar y reintentar
         if (attempt < maxAttempts) {
-          const delay = resolverDelay(categorized, attempt, { baseDelay, maxDelay, multiplier });
+          const delay = resolverDelay(categorized, attempt, {
+            baseDelay,
+            maxDelay,
+            multiplier,
+            jitter,
+          });
+          const elapsed = Date.now() - startTime;
+
+          // El presupuesto acota la duración total; maxAttempts por sí solo no.
+          if (elapsed + delay >= maxTotalTime) {
+            console.log(
+              `[Backoff] ⏱️  Presupuesto de ${maxTotalTime}ms agotado tras ${elapsed}ms ` +
+                `(${categorized.type}) — sin más reintentos`,
+            );
+            return {
+              success: false,
+              error: lastError,
+              attempts: attempt + 1,
+              totalTime: elapsed,
+            };
+          }
+
           console.log(
             `[Backoff] ⚠️  Intento ${attempt + 1}/${maxAttempts + 1} falló (${categorized.type}). ` +
               `Esperando ${delay}ms antes de reintentar... (Error: ${lastError.message})`,
@@ -175,9 +220,9 @@ export async function exponentialBackoff<T>(
 
 /**
  * Envoltorio para exponential backoff que lanza excepción en caso de fallo
- * 
+ *
  * Sintaxis más limpia cuando se quieren excepciones en caso de fallo.
- * 
+ *
  * @param fn Función a ejecutar
  * @param maxAttempts Máximo de reintentos (default: 4)
  * @returns Datos en caso de éxito

--- a/src/platform/vtex/helpers.ts
+++ b/src/platform/vtex/helpers.ts
@@ -96,7 +96,9 @@ export function createVtexScraper(
         `[${storeName}] Error al obtener productos:`,
         toLogSafeError(error),
       );
-      return [];
+      // Se relanza para que backoff pueda reintentar y el router caiga al caché
+      // por tienda. Devolver [] hacía pasar el fallo por "sin resultados".
+      throw error;
     }
   };
 }

--- a/src/scrapers/carrefour/index.ts
+++ b/src/scrapers/carrefour/index.ts
@@ -146,6 +146,8 @@ export async function scrapeCarrefour(query: string): Promise<Product[]> {
       "Error fetching products from Carrefour:",
       toLogSafeError(error),
     );
-    return [];
+    // Se relanza para que backoff pueda reintentar y el router caiga al caché
+    // por tienda. Devolver [] hacía pasar el fallo por "sin resultados".
+    throw error;
   }
 }

--- a/src/scrapers/fravega/__tests__/fravega.test.ts
+++ b/src/scrapers/fravega/__tests__/fravega.test.ts
@@ -45,7 +45,7 @@ describe("scrapeFravega — error logging", () => {
   it("never writes the ScraperAPI key to the log when the request fails", async () => {
     mockGet.mockRejectedValue(timeoutErrorCarryingTheKey());
 
-    await scrapeFravega("tv");
+    await expect(scrapeFravega("tv")).rejects.toThrow();
 
     const logged = errorSpy.mock.calls.flat().join(" ");
     expect(logged).not.toContain(API_KEY);
@@ -54,7 +54,7 @@ describe("scrapeFravega — error logging", () => {
   it("still logs enough to diagnose the failure", async () => {
     mockGet.mockRejectedValue(timeoutErrorCarryingTheKey());
 
-    await scrapeFravega("tv");
+    await expect(scrapeFravega("tv")).rejects.toThrow();
 
     const logged = errorSpy.mock.calls.flat().join(" ");
     expect(logged).toContain("Fravega");
@@ -62,9 +62,41 @@ describe("scrapeFravega — error logging", () => {
     expect(logged).toContain("ECONNABORTED");
   });
 
-  it("returns an empty array so the per-store fallback still applies", async () => {
+  it("rethrows so backoff and the per-store cache fallback can react", async () => {
     mockGet.mockRejectedValue(timeoutErrorCarryingTheKey());
 
-    await expect(scrapeFravega("tv")).resolves.toEqual([]);
+    await expect(scrapeFravega("tv")).rejects.toThrow(
+      "timeout of 23000ms exceeded",
+    );
+  });
+});
+
+describe("scrapeFravega — failure vs. no results", () => {
+  const originalEnv = process.env;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, SCRAPER_API_KEY: API_KEY };
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    errorSpy.mockRestore();
+  });
+
+  it("returns [] without throwing when the store legitimately has no matches", async () => {
+    mockGet.mockResolvedValue({ data: "<html><body></body></html>" });
+
+    await expect(scrapeFravega("producto inexistente")).resolves.toEqual([]);
+  });
+
+  it("does not log an error for a legitimately empty result", async () => {
+    mockGet.mockResolvedValue({ data: "<html><body></body></html>" });
+
+    await scrapeFravega("producto inexistente");
+
+    expect(errorSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/scrapers/fravega/index.ts
+++ b/src/scrapers/fravega/index.ts
@@ -105,6 +105,8 @@ export async function scrapeFravega(query: string): Promise<Product[]> {
       "Error fetching products from Fravega:",
       toLogSafeError(error),
     );
-    return [];
+    // Se relanza para que backoff pueda reintentar y el router caiga al caché
+    // por tienda. Devolver [] hacía pasar el fallo por "sin resultados".
+    throw error;
   }
 }

--- a/src/scrapers/mercadolibre/index.ts
+++ b/src/scrapers/mercadolibre/index.ts
@@ -43,6 +43,8 @@ export async function scrapeMercadoLibre(query: string): Promise<Product[]> {
       "Error fetching products from MercadoLibre:",
       toLogSafeError(error),
     );
-    return [];
+    // Se relanza para que backoff pueda reintentar y el router caiga al caché
+    // por tienda. Devolver [] hacía pasar el fallo por "sin resultados".
+    throw error;
   }
 }


### PR DESCRIPTION
> **Stacked on #134.** Base branch is `fix/redact-secrets-in-error-logs` so the diff shows only this change. Merge #134 first; the base retargets to `master` automatically.

## Problem

Every scraper ended with `catch → console.error → return []`. Backoff received a valid empty array and concluded the call succeeded. Production logs, verbatim:

```
Error fetching products from Fravega: timeout of 23000ms exceeded
[Backoff] ✅ Éxito en intento 1/5 (23009ms)
[Router] store=fravega attempt=1 outcome=success
```

The scraper failed and the retry layer celebrated. Three consequences, all silent:

1. **The 4-retry policy never fired** on scraper failures. `platform/backoff` — jitter, error categorisation, `Retry-After` handling — was dead code on the path that needed it most.
2. **The per-store cache fallback never engaged.** `router.ts` falls back to the 24h store cache only when `success === false`. A failing store returned nothing instead of its cached results.
3. **`/api/health` was blind.** `probeStore` reads `count: 0` with no throw as `status: "ok"`, so the health-check cron never alerted on a broken scraper. The monitoring pipeline described in the README could not see the exact failure mode it exists to catch.

## Changes

**Scrapers rethrow after logging** — `fravega`, `mercadolibre`, `carrefour` and the `createVtexScraper` factory. A genuinely empty result still returns `[]` from the happy path, so "no matches" and "request failed" stop being the same value. The inner Carrefour redirect guards (origin mismatch, `javascript:` URLs) keep returning `[]` — those are deliberate rejections, not failures.

**`exponentialBackoff` gains `maxTotalTime`** (default 25s). `maxAttempts` alone does not bound duration: retrying a 23s timeout four times would block the request for over two minutes (5 × 23s + 2s+4s+8s+16s ≈ 145s). The budget is checked before each wait; if the next delay does not fit, it stops and the caller proceeds to its fallback.

**`exponentialBackoff` gains `jitter`** (default 1000ms — unchanged behaviour). The budget could not be tested deterministically while jitter was a hardcoded `Math.random() * 1000`.

**`router.ts` passes `STORE_RETRY_BUDGET_MS` (10s).** Stores run in parallel, so the slowest sets the latency of `/api/scrape`. Without a budget, MercadoLibre's permanent 403 would burn 2s+4s+8s+16s per search with no chance of success.

### Measured effect per store on a cache miss

| Store | Before | After |
|---|---|---|
| Fravega (23s timeout) | 1 attempt, reported success, no fallback | 1 attempt, budget stops retries, **falls back to store cache** |
| MercadoLibre (403, ~200ms) | 1 attempt, reported success, no fallback | ~3 attempts within 10s, then store cache |

The win is not the retries. It is the **24h store cache fallback that was unreachable** — a failing store now serves cached prices instead of nothing.

### Known limitation

The budget does not bound the *first* attempt: an in-flight request cannot be interrupted from the backoff loop. That limit belongs to the `platform/http` timeout (currently 8s connect + 15s response = 23s). Documented in the code.

## Tests

TDD — written failing first.

- `platform/backoff/__tests__/backoff.test.ts` — 4 new cases: budget stops retries when the next delay does not fit, no retry when the first attempt already consumed the budget, successful calls unaffected, a default budget applies with no explicit config.
- `scrapers/fravega/__tests__/fravega.test.ts` — rethrow on failure, and a new group asserting a legitimately empty result still returns `[]` **without** logging an error.
- `features/price-search/__tests__/router.test.ts` — asserts the router passes a bounded per-store budget.

`npm test` → 44 suites, 299 tests passing. `npm run lint` clean (one pre-existing warning in `e2e/happy-path.spec.ts`). `npm run build` succeeds.

## ⚠️ Operational consequence — read before merging

`/api/health` will now correctly report Fravega and MercadoLibre as `down`. The health-check cron runs **every 10 minutes** and emails `ALERT_EMAIL` whenever status is not `ok`.

With both stores currently broken in production, that is **~144 emails per day** starting at deploy.

This PR does not silence it, on purpose — the alerts are correct and the current silence is the bug. But pick one before merging:

1. Fix the two upstream failures first (MercadoLibre 403 looks like a User-Agent block; Fravega times out at 23s through ScraperAPI), or
2. Add throttling/deduplication to `/api/health-check` so it only alerts on status transitions.

Happy to do either as a follow-up.