### PR TITLE
fix(fravega): request directly first, use ScraperAPI only as fallback

### DIFF
--- a/src/scrapers/fravega/__tests__/fravega.test.ts
+++ b/src/scrapers/fravega/__tests__/fravega.test.ts
@@ -71,6 +71,89 @@ describe("scrapeFravega — error logging", () => {
   });
 });
 
+describe("scrapeFravega — direct first, proxy as fallback", () => {
+  const originalEnv = process.env;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  const DIRECT_URL = "https://www.fravega.com/l/?keyword=samsung%2065";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv, SCRAPER_API_KEY: API_KEY };
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("hits Fravega directly first, without the proxy", async () => {
+    mockGet.mockResolvedValue({ data: "<html></html>" });
+
+    await scrapeFravega("samsung 65");
+
+    expect(mockGet).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledWith(DIRECT_URL, expect.any(Object));
+  });
+
+  it("never calls the proxy when the direct request succeeds", async () => {
+    mockGet.mockResolvedValue({ data: "<html></html>" });
+
+    await scrapeFravega("samsung 65");
+
+    const urls = mockGet.mock.calls.map((call) => call[0] as string);
+    expect(urls.some((url) => url.includes("scraperapi"))).toBe(false);
+  });
+
+  it("falls back to the proxy when the direct request fails", async () => {
+    mockGet
+      .mockRejectedValueOnce(new Error("Request failed with status code 403"))
+      .mockResolvedValueOnce({ data: "<html></html>" });
+
+    await scrapeFravega("samsung 65");
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    const proxyUrl = mockGet.mock.calls[1][0] as string;
+    expect(proxyUrl).toContain("api.scraperapi.com");
+    expect(proxyUrl).toContain(encodeURIComponent(DIRECT_URL));
+  });
+
+  it("does not leak the key when logging the direct failure", async () => {
+    mockGet
+      .mockRejectedValueOnce(new Error("Request failed with status code 403"))
+      .mockResolvedValueOnce({ data: "<html></html>" });
+
+    await scrapeFravega("samsung 65");
+
+    const logged = warnSpy.mock.calls.flat().join(" ");
+    expect(logged).not.toContain(API_KEY);
+  });
+
+  it("rethrows the direct failure when no proxy key is configured", async () => {
+    process.env = { ...originalEnv };
+    delete process.env.SCRAPER_API_KEY;
+    mockGet.mockRejectedValue(new Error("Request failed with status code 403"));
+
+    await expect(scrapeFravega("samsung 65")).rejects.toThrow(
+      "Request failed with status code 403",
+    );
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("rethrows when both the direct request and the proxy fail", async () => {
+    mockGet
+      .mockRejectedValueOnce(new Error("direct 403"))
+      .mockRejectedValueOnce(new Error("proxy timeout"));
+
+    await expect(scrapeFravega("samsung 65")).rejects.toThrow("proxy timeout");
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe("scrapeFravega — failure vs. no results", () => {
   const originalEnv = process.env;
   let errorSpy: jest.SpyInstance;

--- a/src/scrapers/fravega/index.ts
+++ b/src/scrapers/fravega/index.ts
@@ -42,23 +42,56 @@ function extraerMarcasDesdeNextData(html: string): Map<string, string> {
   return marcasPorId;
 }
 
-function buildFravegaUrl(query: string): string {
-  const target = `https://www.fravega.com/l/?keyword=${encodeURIComponent(query)}`;
-  const apiKey = process.env.SCRAPER_API_KEY;
-  if (!apiKey) return target;
+const REQUEST_HEADERS = {
+  "User-Agent":
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
+  Referer: "https://www.fravega.com/",
+};
+
+function buildDirectUrl(query: string): string {
+  return `https://www.fravega.com/l/?keyword=${encodeURIComponent(query)}`;
+}
+
+function buildProxyUrl(target: string, apiKey: string): string {
   return `https://api.scraperapi.com?api_key=${apiKey}&url=${encodeURIComponent(target)}`;
 }
 
-export async function scrapeFravega(query: string): Promise<Product[]> {
-  const url = buildFravegaUrl(query);
+/**
+ * Pide el HTML directo y sólo cae al proxy si el request directo falla.
+ *
+ * Antes se iba siempre por ScraperAPI cuando había key configurada, lo que
+ * costaba ~23s y terminaba en timeout. El request directo responde en ~2s.
+ * El proxy queda como red de contención para cuando Fravega bloquea la IP de
+ * salida — el motivo por el que se lo agregó.
+ */
+async function fetchFravegaHtml(query: string): Promise<string> {
+  const target = buildDirectUrl(query);
+
   try {
-    const { data } = await httpClient.get<string>(url, {
-      headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-        Referer: "https://www.fravega.com/",
-      },
+    const { data } = await httpClient.get<string>(target, {
+      headers: REQUEST_HEADERS,
     });
+    return data;
+  } catch (directError) {
+    const apiKey = process.env.SCRAPER_API_KEY;
+    if (!apiKey) throw directError;
+
+    console.warn(
+      "[fravega] Request directo falló, reintentando vía proxy:",
+      toLogSafeError(directError),
+    );
+
+    const { data } = await httpClient.get<string>(
+      buildProxyUrl(target, apiKey),
+      { headers: REQUEST_HEADERS },
+    );
+    return data;
+  }
+}
+
+export async function scrapeFravega(query: string): Promise<Product[]> {
+  try {
+    const data = await fetchFravegaHtml(query);
     const $ = load(data);
     const marcasPorId = extraerMarcasDesdeNextData(data);
 


### PR DESCRIPTION
> **Stacked on #135**, which is stacked on #134. Merge in order; bases retarget automatically.

## Measurement

Not a hypothesis — measured against the live endpoints:

| Path | Result |
|---|---|
| `GET https://www.fravega.com/l/?keyword=samsung%2065` (direct) | **HTTP 200 in 2.07s**, 727KB HTML |
| Through ScraperAPI | no response within the 23s client timeout, consistently |

`buildFravegaUrl` routed through the proxy whenever `SCRAPER_API_KEY` was set, so the slow path was the **only** path. Fravega was the slowest store in every search, and its results came from the 24h cache at best — nothing at worst.

## Change

`fetchFravegaHtml` requests the direct URL first and falls back to ScraperAPI only if that fails.

The proxy stays as a safety net for the reason it was added (see CHANGELOG: *"resolve 403 on Fravega and MercadoLibre in production"*) — Fravega blocking the egress IP. **That case cannot be reproduced from a dev machine**: what gets blocked is Vercel's datacenter ranges, not a home connection. So the proxy is kept rather than removed, and the fallback covers it.

If the direct request fails and no key is configured, the error propagates unchanged, so backoff and the per-store cache fallback (#135) still apply.

Also extracts the duplicated request headers.

## Expected effect in production

| | Before | After (direct works) | After (IP blocked) |
|---|---|---|---|
| Latency | 23s timeout | ~2s | ~0.5s + proxy time |
| Result | store cache or nothing | live prices | proxy path, as today |

## Tests

TDD — written failing first. 6 new cases in `scrapers/fravega/__tests__/fravega.test.ts`:

- hits the direct URL first
- never touches the proxy when direct succeeds
- falls back to the proxy on direct failure, with the target correctly encoded
- the fallback warning does not leak the API key
- rethrows the direct failure when no key is configured
- rethrows when both direct and proxy fail

`npm test` → 44 suites, 305 tests passing. Lint clean (one pre-existing warning). Build succeeds.

## Not covered here: MercadoLibre

The 403 is **not** a User-Agent block — I verified both `axios/1.7.7` and a browser UA get an identical `{"message":"forbidden","error":"forbidden","status":403,"cause":[]}`.

The endpoint now requires OAuth: `Authorization: Bearer <access_token>`, tokens expiring every 6 hours. That needs an app registered in the MercadoLibre developer console, credentials in env, and token caching + refresh — a feature, not a patch. Tracked separately.