### PR TITLE
feat(mercadolibre): authenticate with OAuth client_credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,17 +135,31 @@ export const scrapeNombre = createVtexScraper(
 
 ## Variables de entorno
 
-| Variable          | Entorno      | Descripción                                                                                                                                    |
-| ----------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `REDIS_URL`       | Local + Prod | Host de Redis (`127.0.0.1` local)                                                                                                              |
-| `REDIS_PORT`      | Local + Prod | Puerto de Redis (`6379` local)                                                                                                                 |
-| `REDIS_PASSWORD`  | Solo prod    | Omitir en local                                                                                                                                |
-| `API_SECRET_KEY`  | Solo prod    | Se requiere el header `x-api-key` en prod; en dev se omite                                                                                     |
-| `RESEND_API_KEY`  | Solo prod    | API key de [Resend](https://resend.com) para alertas por email                                                                                 |
-| `ALERT_EMAIL`     | Solo prod    | Email destino de las alertas de scrapers caídos                                                                                                |
-| `SCRAPER_API_KEY` | Opcional     | API key de [ScraperAPI](https://www.scraperapi.com), usada como proxy para Fravega. Sin ella, Fravega se consulta directo y puede devolver 403 |
+| Variable             | Entorno      | Descripción                                                                                                                                    |
+| -------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REDIS_URL`          | Local + Prod | Host de Redis (`127.0.0.1` local)                                                                                                              |
+| `REDIS_PORT`         | Local + Prod | Puerto de Redis (`6379` local)                                                                                                                 |
+| `REDIS_PASSWORD`     | Solo prod    | Omitir en local                                                                                                                                |
+| `API_SECRET_KEY`     | Solo prod    | Se requiere el header `x-api-key` en prod; en dev se omite                                                                                     |
+| `RESEND_API_KEY`     | Solo prod    | API key de [Resend](https://resend.com) para alertas por email                                                                                 |
+| `ALERT_EMAIL`        | Solo prod    | Email destino de las alertas de scrapers caídos                                                                                                |
+| `SCRAPER_API_KEY`    | Opcional     | API key de [ScraperAPI](https://www.scraperapi.com), usada como proxy para Fravega. Sin ella, Fravega se consulta directo y puede devolver 403 |
+| `MELI_CLIENT_ID`     | Local + Prod | App ID de MercadoLibre. Sin él, la tienda devuelve 403                                                                                         |
+| `MELI_CLIENT_SECRET` | Local + Prod | Secret de la app de MercadoLibre                                                                                                               |
 
 > `CRON_SECRET` y `VERCEL_PROJECT_PRODUCTION_URL` los genera Vercel automáticamente.
+
+### Credenciales de MercadoLibre
+
+La API de búsqueda de MercadoLibre dejó de aceptar requests anónimos: responde
+`403 {"error":"forbidden"}` sin header `Authorization`.
+
+1. Crear una aplicación en [developers.mercadolibre.com.ar](https://developers.mercadolibre.com.ar/devcenter)
+2. Copiar el **App ID** a `MELI_CLIENT_ID` y la **Secret Key** a `MELI_CLIENT_SECRET`
+
+No hace falta configurar redirect URI ni autorizar usuarios: se usa el grant
+`client_credentials`, que sólo da acceso a datos públicos. El token dura 6h y
+`src/platform/meli/token.ts` lo renueva y lo cachea solo.
 
 ---
 

--- a/src/platform/errors/__tests__/categorizer.test.ts
+++ b/src/platform/errors/__tests__/categorizer.test.ts
@@ -8,11 +8,36 @@ import {
   ErrorType,
   isRetriable,
   getRetryDelay,
-} from '@/platform/errors';
+} from "@/platform/errors";
 
-describe('Categorizador de Errores', () => {
-  describe('categorizeHttpError', () => {
-    it('debería categorizar 429 como RATE_LIMITED', () => {
+describe("Categorizador de Errores", () => {
+  describe("errores que se declaran no reintentables", () => {
+    it("respeta retriable=false y corta los reintentos", () => {
+      const error = Object.assign(new Error("faltan credenciales"), {
+        retriable: false,
+      });
+
+      const result = categorizeError(error);
+
+      expect(result.retriable).toBe(false);
+      expect(result.message).toContain("faltan credenciales");
+    });
+
+    it("no altera los errores que no declaran el flag", () => {
+      expect(categorizeError(new Error("fallo genérico")).retriable).toBe(true);
+    });
+
+    it("no trata retriable=true como señal de corte", () => {
+      const error = Object.assign(new Error("fallo transitorio"), {
+        retriable: true,
+      });
+
+      expect(categorizeError(error).retriable).toBe(true);
+    });
+  });
+
+  describe("categorizeHttpError", () => {
+    it("debería categorizar 429 como RATE_LIMITED", () => {
       const error = categorizeHttpError(429);
 
       expect(error.type).toBe(ErrorType.RATE_LIMITED);
@@ -20,7 +45,7 @@ describe('Categorizador de Errores', () => {
       expect(error.statusCode).toBe(429);
     });
 
-    it('debería categorizar 403 como BLOCKING', () => {
+    it("debería categorizar 403 como BLOCKING", () => {
       const error = categorizeHttpError(403);
 
       expect(error.type).toBe(ErrorType.BLOCKING);
@@ -28,7 +53,7 @@ describe('Categorizador de Errores', () => {
       expect(error.statusCode).toBe(403);
     });
 
-    it('debería categorizar 404 como NOT_FOUND', () => {
+    it("debería categorizar 404 como NOT_FOUND", () => {
       const error = categorizeHttpError(404);
 
       expect(error.type).toBe(ErrorType.NOT_FOUND);
@@ -36,7 +61,7 @@ describe('Categorizador de Errores', () => {
       expect(error.statusCode).toBe(404);
     });
 
-    it('debería categorizar errores 5xx como SERVER_ERROR', () => {
+    it("debería categorizar errores 5xx como SERVER_ERROR", () => {
       [500, 502, 503, 504].forEach((code) => {
         const error = categorizeHttpError(code);
         expect(error.type).toBe(ErrorType.SERVER_ERROR);
@@ -45,13 +70,13 @@ describe('Categorizador de Errores', () => {
       });
     });
 
-    it('debería respetar el header Retry-After', () => {
-      const error = categorizeHttpError(429, '60');
+    it("debería respetar el header Retry-After", () => {
+      const error = categorizeHttpError(429, "60");
 
       expect(error.retryDelay).toBe(60);
     });
 
-    it('debería categorizar códigos desconocidos como UNKNOWN', () => {
+    it("debería categorizar códigos desconocidos como UNKNOWN", () => {
       const error = categorizeHttpError(418); // Soy una tetera
 
       expect(error.type).toBe(ErrorType.UNKNOWN);
@@ -59,50 +84,50 @@ describe('Categorizador de Errores', () => {
     });
   });
 
-  describe('categorizeError', () => {
-    it('debería detectar ECONNREFUSED', () => {
-      const error = new Error('ECONNREFUSED');
+  describe("categorizeError", () => {
+    it("debería detectar ECONNREFUSED", () => {
+      const error = new Error("ECONNREFUSED");
       const categorized = categorizeError(error);
 
       expect(categorized.type).toBe(ErrorType.NETWORK_ERROR);
       expect(categorized.retriable).toBe(true);
     });
 
-    it('debería detectar errores de timeout', () => {
-      const error = new Error('Request timeout');
+    it("debería detectar errores de timeout", () => {
+      const error = new Error("Request timeout");
       const categorized = categorizeError(error);
 
       expect(categorized.type).toBe(ErrorType.TIMEOUT);
       expect(categorized.retriable).toBe(true);
     });
 
-    it('debería detectar ENOTFOUND (DNS)', () => {
-      const error = new Error('getaddrinfo ENOTFOUND example.com');
+    it("debería detectar ENOTFOUND (DNS)", () => {
+      const error = new Error("getaddrinfo ENOTFOUND example.com");
       const categorized = categorizeError(error);
 
       expect(categorized.type).toBe(ErrorType.NETWORK_ERROR);
       expect(categorized.retriable).toBe(true);
     });
 
-    it('debería detectar ECONNRESET', () => {
-      const error = new Error('ECONNRESET');
+    it("debería detectar ECONNRESET", () => {
+      const error = new Error("ECONNRESET");
       const categorized = categorizeError(error);
 
       expect(categorized.type).toBe(ErrorType.NETWORK_ERROR);
       expect(categorized.retriable).toBe(true);
     });
 
-    it('debería detectar que se requiere JavaScript', () => {
-      const error = new Error('Content requires JavaScript rendering');
+    it("debería detectar que se requiere JavaScript", () => {
+      const error = new Error("Content requires JavaScript rendering");
       const categorized = categorizeError(error);
 
       expect(categorized.type).toBe(ErrorType.JAVASCRIPT_REQUIRED);
       expect(categorized.retriable).toBe(true);
     });
 
-    it('debería detectar contenido HTML pequeño como que requiere JavaScript', () => {
-      const smallHtml = '<html></html>';
-      const error = new Error('Some error');
+    it("debería detectar contenido HTML pequeño como que requiere JavaScript", () => {
+      const smallHtml = "<html></html>";
+      const error = new Error("Some error");
       const categorized = categorizeError(error, smallHtml);
 
       // Podrá ser marcado como retriable aunque el error original es desconocido
@@ -110,33 +135,33 @@ describe('Categorizador de Errores', () => {
       expect(categorized.retriable).toBe(true);
     });
 
-    it('debería manejar null/undefined', () => {
+    it("debería manejar null/undefined", () => {
       const categorized = categorizeError(null);
 
       expect(categorized.type).toBe(ErrorType.UNKNOWN);
       expect(categorized.retriable).toBe(false);
     });
 
-    it('debería manejar errores de string', () => {
-      const categorized1 = categorizeError('timeout occurred');
+    it("debería manejar errores de string", () => {
+      const categorized1 = categorizeError("timeout occurred");
       expect(categorized1.type).toBe(ErrorType.TIMEOUT);
       expect(categorized1.retriable).toBe(true);
 
-      const categorized2 = categorizeError('network connection failed');
+      const categorized2 = categorizeError("network connection failed");
       expect(categorized2.type).toBe(ErrorType.NETWORK_ERROR);
       expect(categorized2.retriable).toBe(true);
     });
 
-    it('debería marcar errores desconocidos como retriable por defecto', () => {
-      const error = new Error('Some weird error');
+    it("debería marcar errores desconocidos como retriable por defecto", () => {
+      const error = new Error("Some weird error");
       const categorized = categorizeError(error);
 
       expect(categorized.retriable).toBe(true);
     });
   });
 
-  describe('isRetriable', () => {
-    it('debería devolver true para tipos de error recuperables', () => {
+  describe("isRetriable", () => {
+    it("debería devolver true para tipos de error recuperables", () => {
       const retriableTypes = [
         ErrorType.RATE_LIMITED,
         ErrorType.BLOCKING,
@@ -151,7 +176,7 @@ describe('Categorizador de Errores', () => {
       });
     });
 
-    it('debería devolver false para tipos de error no recuperables', () => {
+    it("debería devolver false para tipos de error no recuperables", () => {
       const nonRetriableTypes = [ErrorType.NOT_FOUND, ErrorType.UNKNOWN];
 
       nonRetriableTypes.forEach((type) => {
@@ -160,11 +185,11 @@ describe('Categorizador de Errores', () => {
     });
   });
 
-  describe('getRetryDelay', () => {
-    it('debería usar el delay proporcionado por el servidor si está disponible', () => {
+  describe("getRetryDelay", () => {
+    it("debería usar el delay proporcionado por el servidor si está disponible", () => {
       const error = {
         type: ErrorType.RATE_LIMITED,
-        message: 'Rate limited',
+        message: "Rate limited",
         retriable: true,
         retryDelay: 30, // 30 segundos del header Retry-After
       };
@@ -173,7 +198,7 @@ describe('Categorizador de Errores', () => {
       expect(delay).toBe(30000); // Convertir a milisegundos
     });
 
-    it('debería usar delay por defecto según el tipo de error', () => {
+    it("debería usar delay por defecto según el tipo de error", () => {
       const testCases = [
         [ErrorType.RATE_LIMITED, 5000],
         [ErrorType.BLOCKING, 10000],
@@ -185,7 +210,7 @@ describe('Categorizador de Errores', () => {
       testCases.forEach(([type, expectedDelay]) => {
         const error = {
           type: type as ErrorType,
-          message: 'Test error',
+          message: "Test error",
           retriable: true,
         };
 
@@ -194,10 +219,10 @@ describe('Categorizador de Errores', () => {
       });
     });
 
-    it('debería devolver undefined para tipos desconocidos sin delay del servidor', () => {
+    it("debería devolver undefined para tipos desconocidos sin delay del servidor", () => {
       const error = {
         type: ErrorType.UNKNOWN,
-        message: 'Unknown',
+        message: "Unknown",
         retriable: false,
       };
 

--- a/src/platform/errors/index.ts
+++ b/src/platform/errors/index.ts
@@ -114,6 +114,15 @@ export function categorizeError(
   htmlContent?: string,
 ): CategorizedError {
   if (!error) return categorizarNulo();
+  // Un error puede declararse no reintentable (ej. configuración faltante).
+  // Reintentar eso sólo multiplica el ruido: nunca va a tener éxito.
+  if (esNoReintentableExplicito(error)) {
+    return {
+      type: ErrorType.UNKNOWN,
+      message: error instanceof Error ? error.message : String(error),
+      retriable: false,
+    };
+  }
   if (error instanceof Error) return categorizarInstanciaError(error);
   if (typeof error === "string") return categorizarErrorString(error);
   if (htmlContent) return categorizarHtml(htmlContent);
@@ -124,6 +133,15 @@ export function categorizeError(
     retriable: false,
     details: { originalError: String(error) },
   };
+}
+
+/** Detecta el opt-out explícito `retriable: false` en el objeto de error. */
+function esNoReintentableExplicito(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    (error as { retriable?: unknown }).retriable === false
+  );
 }
 
 function categorizarNulo(): CategorizedError {

--- a/src/platform/meli/__tests__/token.test.ts
+++ b/src/platform/meli/__tests__/token.test.ts
@@ -1,0 +1,198 @@
+import {
+  getMeliAccessToken,
+  invalidateMeliToken,
+  MeliAuthError,
+  MELI_TOKEN_CACHE_KEY,
+} from "../token";
+
+jest.mock("@/platform/http", () => ({
+  httpClient: { post: jest.fn() },
+}));
+
+jest.mock("@/platform/redis", () => ({
+  __esModule: true,
+  default: { get: jest.fn(), set: jest.fn(), del: jest.fn() },
+}));
+
+import { httpClient } from "@/platform/http";
+import redis from "@/platform/redis";
+
+const mockPost = httpClient.post as jest.Mock;
+const mockRedisGet = redis.get as jest.Mock;
+const mockRedisSet = redis.set as jest.Mock;
+const mockRedisDel = redis.del as jest.Mock;
+
+const tokenResponse = (token = "APP_USR-token-abc", expiresIn = 21600) => ({
+  data: { access_token: token, token_type: "bearer", expires_in: expiresIn },
+});
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  invalidateMeliToken();
+  process.env = {
+    ...originalEnv,
+    MELI_CLIENT_ID: "1234567890",
+    MELI_CLIENT_SECRET: "client-secret-value",
+  };
+  mockRedisGet.mockResolvedValue(null);
+  mockRedisSet.mockResolvedValue("OK");
+  mockRedisDel.mockResolvedValue(1);
+});
+
+afterEach(() => {
+  process.env = originalEnv;
+  invalidateMeliToken();
+});
+
+describe("getMeliAccessToken — obtaining a token", () => {
+  it("requests a token with the client_credentials grant", async () => {
+    mockPost.mockResolvedValue(tokenResponse());
+
+    const token = await getMeliAccessToken();
+
+    expect(token).toBe("APP_USR-token-abc");
+    expect(mockPost).toHaveBeenCalledTimes(1);
+
+    const [url, body, config] = mockPost.mock.calls[0];
+    expect(url).toBe("https://api.mercadolibre.com/oauth/token");
+    expect(config.headers["Content-Type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+
+    const params = new URLSearchParams(body as string);
+    expect(params.get("grant_type")).toBe("client_credentials");
+    expect(params.get("client_id")).toBe("1234567890");
+    expect(params.get("client_secret")).toBe("client-secret-value");
+  });
+
+  it("throws a clear error when credentials are not configured", async () => {
+    process.env = { ...originalEnv };
+    delete process.env.MELI_CLIENT_ID;
+    delete process.env.MELI_CLIENT_SECRET;
+
+    await expect(getMeliAccessToken()).rejects.toBeInstanceOf(MeliAuthError);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("marks the missing-credentials error as non-retriable", async () => {
+    process.env = { ...originalEnv };
+    delete process.env.MELI_CLIENT_ID;
+    delete process.env.MELI_CLIENT_SECRET;
+
+    const error = await getMeliAccessToken().catch((e: MeliAuthError) => e);
+
+    expect((error as MeliAuthError).retriable).toBe(false);
+  });
+
+  it("keeps a failed token request retriable — it may be transient", async () => {
+    mockPost.mockRejectedValue(new Error("gateway timeout"));
+
+    const error = await getMeliAccessToken().catch((e: MeliAuthError) => e);
+
+    expect((error as MeliAuthError).retriable).toBe(true);
+  });
+
+  it("does not leak the client secret in the thrown error", async () => {
+    mockPost.mockRejectedValue(new Error("invalid_client"));
+
+    await expect(getMeliAccessToken()).rejects.toThrow();
+
+    const thrown = await getMeliAccessToken().catch((e: Error) => e.message);
+    expect(thrown).not.toContain("client-secret-value");
+  });
+});
+
+describe("getMeliAccessToken — caching", () => {
+  it("reuses the in-memory token instead of requesting a new one", async () => {
+    mockPost.mockResolvedValue(tokenResponse());
+
+    await getMeliAccessToken();
+    await getMeliAccessToken();
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the token in Redis with a TTL below the real expiry", async () => {
+    mockPost.mockResolvedValue(tokenResponse("APP_USR-token-abc", 21600));
+
+    await getMeliAccessToken();
+
+    expect(mockRedisSet).toHaveBeenCalledWith(
+      MELI_TOKEN_CACHE_KEY,
+      "APP_USR-token-abc",
+      expect.objectContaining({ ex: expect.any(Number) }),
+    );
+    const { ex } = mockRedisSet.mock.calls[0][2] as { ex: number };
+    expect(ex).toBeLessThan(21600);
+    expect(ex).toBeGreaterThan(0);
+  });
+
+  it("uses a token already cached in Redis without calling the OAuth endpoint", async () => {
+    mockRedisGet.mockResolvedValue("APP_USR-from-redis");
+
+    const token = await getMeliAccessToken();
+
+    expect(token).toBe("APP_USR-from-redis");
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it("still obtains a token when Redis is unavailable", async () => {
+    mockRedisGet.mockRejectedValue(new Error("redis down"));
+    mockRedisSet.mockRejectedValue(new Error("redis down"));
+    mockPost.mockResolvedValue(tokenResponse());
+
+    await expect(getMeliAccessToken()).resolves.toBe("APP_USR-token-abc");
+  });
+});
+
+describe("getMeliAccessToken — concurrency", () => {
+  it("issues a single request when many callers ask at the same time", async () => {
+    mockPost.mockImplementation(
+      async () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve(tokenResponse()), 20),
+        ),
+    );
+
+    const tokens = await Promise.all([
+      getMeliAccessToken(),
+      getMeliAccessToken(),
+      getMeliAccessToken(),
+      getMeliAccessToken(),
+    ]);
+
+    expect(mockPost).toHaveBeenCalledTimes(1);
+    expect(new Set(tokens).size).toBe(1);
+  });
+
+  it("recovers after a failed refresh instead of caching the rejection", async () => {
+    mockPost.mockRejectedValueOnce(new Error("temporary failure"));
+    await expect(getMeliAccessToken()).rejects.toThrow();
+
+    mockPost.mockResolvedValueOnce(tokenResponse());
+    await expect(getMeliAccessToken()).resolves.toBe("APP_USR-token-abc");
+  });
+});
+
+describe("invalidateMeliToken", () => {
+  it("forces the next call to obtain a fresh token", async () => {
+    mockPost.mockResolvedValue(tokenResponse());
+    await getMeliAccessToken();
+
+    invalidateMeliToken();
+    await getMeliAccessToken();
+
+    expect(mockPost).toHaveBeenCalledTimes(2);
+  });
+
+  it("drops the Redis copy so other instances stop reusing it", async () => {
+    mockPost.mockResolvedValue(tokenResponse());
+    await getMeliAccessToken();
+
+    invalidateMeliToken();
+
+    expect(mockRedisDel).toHaveBeenCalledWith(MELI_TOKEN_CACHE_KEY);
+  });
+});

--- a/src/platform/meli/token.ts
+++ b/src/platform/meli/token.ts
@@ -1,0 +1,165 @@
+/**
+ * Token de aplicación de MercadoLibre (OAuth client_credentials).
+ *
+ * La API de búsqueda dejó de aceptar requests anónimos: `/sites/MLA/search`
+ * responde 403 `{"error":"forbidden"}` sin `Authorization`. El grant
+ * `client_credentials` alcanza para datos públicos — no requiere autorización
+ * de un usuario ni refresh_token.
+ *
+ * El token dura 6h. Se cachea en dos niveles:
+ * - memoria del proceso, para no pegarle a Redis en cada request de la misma
+ *   instancia;
+ * - Redis, para que las instancias que arrancan en frío reusen el token vigente
+ *   en lugar de pedir uno nuevo cada una.
+ */
+
+import redis from "@/platform/redis";
+import { httpClient } from "@/platform/http";
+
+export const MELI_TOKEN_CACHE_KEY = "meli:token";
+
+const TOKEN_URL = "https://api.mercadolibre.com/oauth/token";
+
+/**
+ * Margen de seguridad: se renueva antes del vencimiento real para que un token
+ * no expire en medio de una búsqueda ya en curso.
+ */
+const EXPIRY_SAFETY_MARGIN_SECONDS = 600;
+
+/** Error de configuración o de obtención del token. Nunca incluye el secret. */
+export class MeliAuthError extends Error {
+  /**
+   * `false` corta los reintentos del backoff. Falta de credenciales es un error
+   * de configuración: reintentarlo cuatro veces por búsqueda no lo arregla.
+   */
+  readonly retriable: boolean;
+
+  constructor(message: string, retriable = true) {
+    super(message);
+    this.name = "MeliAuthError";
+    this.retriable = retriable;
+  }
+}
+
+interface TokenResponse {
+  access_token: string;
+  token_type: string;
+  expires_in: number;
+}
+
+let memoryToken: { value: string; expiresAt: number } | null = null;
+
+/**
+ * Request de refresh en curso. Sin esto, las 6 tiendas que arrancan en paralelo
+ * pedirían 6 tokens distintos en el primer cache miss.
+ */
+let inFlight: Promise<string> | null = null;
+
+function readCredentials(): { clientId: string; clientSecret: string } {
+  const clientId = process.env.MELI_CLIENT_ID;
+  const clientSecret = process.env.MELI_CLIENT_SECRET;
+
+  if (!clientId || !clientSecret) {
+    throw new MeliAuthError(
+      "MELI_CLIENT_ID y MELI_CLIENT_SECRET son requeridos para consultar MercadoLibre",
+      false,
+    );
+  }
+
+  return { clientId, clientSecret };
+}
+
+async function readFromRedis(): Promise<string | null> {
+  try {
+    const cached = await redis.get<string>(MELI_TOKEN_CACHE_KEY);
+    return typeof cached === "string" && cached.length > 0 ? cached : null;
+  } catch {
+    // Redis caído no debe impedir obtener un token nuevo.
+    return null;
+  }
+}
+
+async function writeToRedis(token: string, ttlSeconds: number): Promise<void> {
+  if (ttlSeconds <= 0) return;
+  try {
+    await redis.set(MELI_TOKEN_CACHE_KEY, token, { ex: ttlSeconds });
+  } catch {
+    // El token sigue siendo válido en memoria aunque no se pueda compartir.
+  }
+}
+
+async function requestNewToken(): Promise<{ token: string; ttl: number }> {
+  const { clientId, clientSecret } = readCredentials();
+
+  const body = new URLSearchParams({
+    grant_type: "client_credentials",
+    client_id: clientId,
+    client_secret: clientSecret,
+  }).toString();
+
+  try {
+    const { data } = await httpClient.post<TokenResponse>(TOKEN_URL, body, {
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
+    });
+
+    if (!data?.access_token) {
+      throw new MeliAuthError("La respuesta de OAuth no incluyó access_token");
+    }
+
+    const ttl = Math.max(
+      0,
+      (data.expires_in ?? 0) - EXPIRY_SAFETY_MARGIN_SECONDS,
+    );
+    return { token: data.access_token, ttl };
+  } catch (error) {
+    if (error instanceof MeliAuthError) throw error;
+    // Se descarta el error original a propósito: su `config.data` contiene el
+    // client_secret del body del request.
+    throw new MeliAuthError("No se pudo obtener el token de MercadoLibre");
+  }
+}
+
+async function resolveToken(): Promise<string> {
+  const cached = await readFromRedis();
+  if (cached) {
+    memoryToken = {
+      value: cached,
+      expiresAt: Date.now() + EXPIRY_SAFETY_MARGIN_SECONDS * 1000,
+    };
+    return cached;
+  }
+
+  const { token, ttl } = await requestNewToken();
+  memoryToken = { value: token, expiresAt: Date.now() + ttl * 1000 };
+  await writeToRedis(token, ttl);
+  return token;
+}
+
+/** Devuelve un token válido, reusando el cacheado mientras no haya vencido. */
+export async function getMeliAccessToken(): Promise<string> {
+  if (memoryToken && Date.now() < memoryToken.expiresAt) {
+    return memoryToken.value;
+  }
+
+  if (inFlight !== null) return inFlight;
+
+  inFlight = resolveToken().finally(() => {
+    // Se libera siempre: cachear una promesa rechazada dejaría la app sin
+    // token hasta el próximo deploy.
+    inFlight = null;
+  });
+
+  return inFlight;
+}
+
+/** Descarta el token cacheado. Se llama ante un 401/403 para forzar refresh. */
+export function invalidateMeliToken(): void {
+  memoryToken = null;
+  inFlight = null;
+  Promise.resolve(redis.del(MELI_TOKEN_CACHE_KEY)).catch(() => {
+    // Best-effort: si Redis no responde, el caché en memoria ya quedó limpio.
+  });
+}

--- a/src/scrapers/mercadolibre/__tests__/mercadolibre.test.ts
+++ b/src/scrapers/mercadolibre/__tests__/mercadolibre.test.ts
@@ -1,0 +1,137 @@
+import { scrapeMercadoLibre } from "@/scrapers/mercadolibre";
+
+jest.mock("@/platform/http", () => ({
+  httpClient: { get: jest.fn() },
+}));
+
+jest.mock("@/platform/meli/token", () => ({
+  getMeliAccessToken: jest.fn(),
+  invalidateMeliToken: jest.fn(),
+}));
+
+import { httpClient } from "@/platform/http";
+import { getMeliAccessToken, invalidateMeliToken } from "@/platform/meli/token";
+
+const mockGet = httpClient.get as jest.Mock;
+const mockGetToken = getMeliAccessToken as jest.Mock;
+const mockInvalidate = invalidateMeliToken as jest.Mock;
+
+const httpError = (status: number) => {
+  const error = new Error(
+    `Request failed with status code ${status}`,
+  ) as Error & {
+    response: { status: number };
+  };
+  error.response = { status };
+  return error;
+};
+
+const searchResponse = () => ({
+  data: {
+    results: [
+      {
+        title: "Smart TV Samsung 65",
+        price: 900000,
+        thumbnail: "https://http2.mlstatic.com/tv-I.jpg",
+        permalink: "https://articulo.mercadolibre.com.ar/MLA-123",
+        attributes: [{ id: "BRAND", value_name: "Samsung" }],
+      },
+    ],
+  },
+});
+
+let errorSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetToken.mockResolvedValue("APP_USR-token-abc");
+  errorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  errorSpy.mockRestore();
+});
+
+describe("scrapeMercadoLibre — authentication", () => {
+  it("sends the access token as a Bearer header", async () => {
+    mockGet.mockResolvedValue(searchResponse());
+
+    await scrapeMercadoLibre("samsung 65");
+
+    expect(mockGet).toHaveBeenCalledWith(
+      expect.stringContaining("/sites/MLA/search"),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer APP_USR-token-abc",
+        }),
+      }),
+    );
+  });
+
+  it("encodes the query in the search URL", async () => {
+    mockGet.mockResolvedValue(searchResponse());
+
+    await scrapeMercadoLibre('samsung 65"');
+
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain("q=samsung%2065%22");
+  });
+
+  it("maps the response to products", async () => {
+    mockGet.mockResolvedValue(searchResponse());
+
+    const result = await scrapeMercadoLibre("samsung 65");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Smart TV Samsung 65");
+    expect(result[0].brand).toBe("Samsung");
+  });
+});
+
+describe("scrapeMercadoLibre — expired token recovery", () => {
+  it("invalidates the token and retries once on 401", async () => {
+    mockGet
+      .mockRejectedValueOnce(httpError(401))
+      .mockResolvedValueOnce(searchResponse());
+    mockGetToken
+      .mockResolvedValueOnce("APP_USR-stale")
+      .mockResolvedValueOnce("APP_USR-fresh");
+
+    const result = await scrapeMercadoLibre("samsung 65");
+
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledTimes(2);
+    expect(mockGet.mock.calls[1][1].headers.Authorization).toBe(
+      "Bearer APP_USR-fresh",
+    );
+    expect(result).toHaveLength(1);
+  });
+
+  it("also retries on 403, the status the API returns without a token", async () => {
+    mockGet
+      .mockRejectedValueOnce(httpError(403))
+      .mockResolvedValueOnce(searchResponse());
+
+    await scrapeMercadoLibre("samsung 65");
+
+    expect(mockInvalidate).toHaveBeenCalledTimes(1);
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries only once — a second auth failure propagates", async () => {
+    mockGet.mockRejectedValue(httpError(401));
+
+    await expect(scrapeMercadoLibre("samsung 65")).rejects.toThrow();
+
+    expect(mockGet).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on errors unrelated to authentication", async () => {
+    mockGet.mockRejectedValue(httpError(500));
+
+    await expect(scrapeMercadoLibre("samsung 65")).rejects.toThrow();
+
+    expect(mockInvalidate).not.toHaveBeenCalled();
+    expect(mockGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/scrapers/mercadolibre/index.ts
+++ b/src/scrapers/mercadolibre/index.ts
@@ -3,6 +3,7 @@ import { Product } from "@/types/product";
 import { StoreNamesEnum } from "@/enums/stores.enum";
 import { httpClient } from "@/platform/http";
 import { toLogSafeError } from "@/platform/errors";
+import { getMeliAccessToken, invalidateMeliToken } from "@/platform/meli/token";
 
 interface MeliAttribute {
   id: string;
@@ -21,10 +22,43 @@ interface MeliSearchResponse {
   results: MeliResult[];
 }
 
+/** 401/403 son las respuestas de la API cuando el token falta o venció. */
+function isAuthFailure(error: unknown): boolean {
+  const status = (error as { response?: { status?: number } })?.response
+    ?.status;
+  return status === 401 || status === 403;
+}
+
+/**
+ * Consulta la API firmando con el token de aplicación.
+ *
+ * Ante un fallo de autenticación descarta el token y reintenta una sola vez:
+ * el token dura 6h y puede vencer entre que se cachea y se usa. Un segundo
+ * fallo se propaga — reintentar más sería enmascarar credenciales inválidas.
+ */
+async function fetchMeliResults(url: string): Promise<MeliSearchResponse> {
+  const requestWith = async (token: string) => {
+    const { data } = await httpClient.get<MeliSearchResponse>(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return data;
+  };
+
+  const token = await getMeliAccessToken();
+  try {
+    return await requestWith(token);
+  } catch (error) {
+    if (!isAuthFailure(error)) throw error;
+
+    invalidateMeliToken();
+    return requestWith(await getMeliAccessToken());
+  }
+}
+
 export async function scrapeMercadoLibre(query: string): Promise<Product[]> {
   const url = `https://api.mercadolibre.com/sites/MLA/search?q=${encodeURIComponent(query)}&limit=50`;
   try {
-    const { data } = await httpClient.get<MeliSearchResponse>(url);
+    const data = await fetchMeliResults(url);
     return data.results.map((item) => {
       const brandAttr = item.attributes.find((a) => a.id === "BRAND");
       const brand = capitalize(brandAttr?.value_name ?? "Unknown");


### PR DESCRIPTION
> **Stacked on #136 → #135 → #134.** Merge in order; bases retarget automatically.

## Problem

`/sites/MLA/search` stopped accepting anonymous requests. It answers `403 {"message":"forbidden","error":"forbidden","status":403,"cause":[]}` with no `Authorization` header.

## Verified before implementing

Two things I checked against the live API rather than assuming — an earlier hypothesis of mine (User-Agent block) turned out to be wrong:

**1. It is authentication, not fingerprinting.** Identical 403 for both User-Agents:

| User-Agent | Status |
|---|---|
| `axios/1.7.7` | 403 |
| Chrome 124 | 403 |

**2. `client_credentials` is supported.** Probed `POST /oauth/token` with fake credentials:

| grant_type | Response |
|---|---|
| `client_credentials` | `{"error":"invalid_client"}` — grant accepted, credentials rejected |
| `no_existe_este_grant` | `{"error":"unsupported_grant_type"}` |

So no user authorization flow and no `refresh_token` dance. The app token covers public search data.

## Design — `src/platform/meli/token.ts`

**Two-level cache.** Process memory avoids a Redis round trip on every request within an instance; Redis lets cold-start instances reuse a live token instead of each minting its own. Redis TTL is the real expiry minus a 10-minute safety margin, so a token never expires mid-search.

**Single-flight.** Six stores start in parallel. Without deduplication, the first cache miss would fire six token requests. Concurrent callers share one in-flight promise, and it is released in `finally` — caching a rejected promise would leave the app tokenless until the next deploy.

**The secret never reaches an error message.** The axios error for the token request carries `client_secret` in `config.data`, so the original error is replaced, not wrapped. This is the same class of leak as #134, at a different layer.

**Redis failures degrade, they do not block.** If Redis is unavailable the token is still obtained and kept in memory.

## Scraper integration

Each request is signed with `Authorization: Bearer <token>`. On **401 or 403**, the token is invalidated and the request retried **exactly once** — the token lives 6h and can expire between being cached and being used. A second auth failure propagates; retrying further would mask invalid credentials as a flaky network.

Errors unrelated to auth are not retried at this layer — that is backoff's job (#135).

## `categorizeError` honours explicit `retriable: false`

`MeliAuthError` for missing credentials is marked non-retriable. Without this, a missing env var would be retried four times per search and look like an intermittent network fault instead of the configuration error it is. A failed *token request* stays retriable — that one can be transient.

The flag is a general opt-out on the error object, not a MercadoLibre special case.

## Tests

TDD — written failing first. 22 new cases.

`platform/meli/__tests__/token.test.ts` (13): correct grant and form encoding, missing credentials error, secret absent from error messages, memory reuse, Redis TTL below real expiry, Redis hit skips OAuth, works with Redis down, single-flight under 4 concurrent callers, recovery after a failed refresh, invalidation forces refresh and drops the Redis copy, retriable flags.

`scrapers/mercadolibre/__tests__/mercadolibre.test.ts` (7): Bearer header sent, query encoded, response mapped, 401 and 403 each trigger one retry with a fresh token, retry happens only once, non-auth errors are not retried.

`platform/errors/__tests__/categorizer.test.ts` (3): the `retriable: false` opt-out.

`npm test` → 46 suites, 328 tests passing. Lint clean (one pre-existing warning). Build succeeds.

## ⚠️ Required before this works

Create an app at [developers.mercadolibre.com.ar](https://developers.mercadolibre.com.ar/devcenter) and set in Vercel:

| Variable | Where to find it |
|---|---|
| `MELI_CLIENT_ID` | App ID |
| `MELI_CLIENT_SECRET` | Secret Key |

No redirect URI or user authorization needed. Documented in the README.

Until these are set, MercadoLibre fails fast with a clear non-retriable error and the other five stores are unaffected.