### PR TITLE
chore(scrapers): disable mercadolibre store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Node.js 20.x required (see `.nvmrc`).
 
 ## Architecture
 
-**Electronics price comparison** for Argentine stores. Scrapes 6+ retailers in parallel, caches in Redis, serves via Next.js API.
+**Electronics price comparison** for Argentine stores. Scrapes 5 retailers in parallel, caches in Redis, serves via Next.js API.
 
 ### Request Flow
 
@@ -62,7 +62,7 @@ GET /api/scrape?query=iphone
 - `router.ts` — Per-store fallback: try scraper → store cache → empty array
 - `hooks/` — Zustand store for client-side state (results, filters, pagination)
 
-**`src/scrapers/`** — One folder per store (naldo, oncity, carrefour, fravega, cetrogar, mercadolibre). VTEX stores use `createVtexScraper` factory from `platform/vtex`.
+**`src/scrapers/`** — One folder per store (naldo, oncity, carrefour, fravega, cetrogar, mercadolibre). VTEX stores use `createVtexScraper` factory from `platform/vtex`. A store folder existing does not mean the store runs: `DISABLED_STORES` in `src/scrapers/index.ts` lists scrapers that are kept in the tree but left out of the registry (currently mercadolibre).
 
 **`src/components/`** — React UI with Storybook stories. `ui/` contains shadcn/ui primitives.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
 # quiendamenos
 
-Comparador de precios de electrónica para tiendas argentinas. Scrapea en paralelo Frávega, Cetrogar, Naldo, Carrefour, OnCity y MercadoLibre, cachea en Redis y sirve los resultados vía Next.js.
+Comparador de precios de electrónica para tiendas argentinas. Scrapea en paralelo Frávega, Cetrogar, Naldo, Carrefour y OnCity, cachea en Redis y sirve los resultados vía Next.js.
 
 ## Tiendas soportadas
 
-| Tienda       | Método     |
-| ------------ | ---------- |
-| Frávega      | VTEX IS    |
-| Cetrogar     | VTEX IS    |
-| Naldo        | VTEX IS    |
-| OnCity       | VTEX IS    |
-| Carrefour    | VTEX IS    |
-| MercadoLibre | API propia |
+| Tienda       | Método     | Estado        |
+| ------------ | ---------- | ------------- |
+| Frávega      | VTEX IS    | Activa        |
+| Cetrogar     | VTEX IS    | Activa        |
+| Naldo        | VTEX IS    | Activa        |
+| OnCity       | VTEX IS    | Activa        |
+| Carrefour    | VTEX IS    | Activa        |
+| MercadoLibre | API propia | Deshabilitada |
+
+MercadoLibre está deshabilitada en `src/scrapers/index.ts` (`DISABLED_STORES`). Sus dos
+vías de acceso están cerradas: la API oficial responde `403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES`
+aun con un token OAuth válido, y el listado HTML está detrás de un challenge de proof-of-work.
+Reactivarla requiere los proxies premium de ScraperAPI. El scraper y el módulo de token OAuth
+se conservan para poder volver a habilitarla sin reescribirlos.
 
 ---
 
@@ -135,15 +141,17 @@ export const scrapeNombre = createVtexScraper(
 
 ## Variables de entorno
 
-| Variable          | Entorno      | Descripción                                                                                                                                    |
-| ----------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| `REDIS_URL`       | Local + Prod | Host de Redis (`127.0.0.1` local)                                                                                                              |
-| `REDIS_PORT`      | Local + Prod | Puerto de Redis (`6379` local)                                                                                                                 |
-| `REDIS_PASSWORD`  | Solo prod    | Omitir en local                                                                                                                                |
-| `API_SECRET_KEY`  | Solo prod    | Se requiere el header `x-api-key` en prod; en dev se omite                                                                                     |
-| `RESEND_API_KEY`  | Solo prod    | API key de [Resend](https://resend.com) para alertas por email                                                                                 |
-| `ALERT_EMAIL`     | Solo prod    | Email destino de las alertas de scrapers caídos                                                                                                |
-| `SCRAPER_API_KEY` | Opcional     | API key de [ScraperAPI](https://www.scraperapi.com), usada como proxy para Fravega. Sin ella, Fravega se consulta directo y puede devolver 403 |
+| Variable             | Entorno      | Descripción                                                                                                                                    |
+| -------------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REDIS_URL`          | Local + Prod | Host de Redis (`127.0.0.1` local)                                                                                                              |
+| `REDIS_PORT`         | Local + Prod | Puerto de Redis (`6379` local)                                                                                                                 |
+| `REDIS_PASSWORD`     | Solo prod    | Omitir en local                                                                                                                                |
+| `API_SECRET_KEY`     | Solo prod    | Se requiere el header `x-api-key` en prod; en dev se omite                                                                                     |
+| `RESEND_API_KEY`     | Solo prod    | API key de [Resend](https://resend.com) para alertas por email                                                                                 |
+| `ALERT_EMAIL`        | Solo prod    | Email destino de las alertas de scrapers caídos                                                                                                |
+| `SCRAPER_API_KEY`    | Opcional     | API key de [ScraperAPI](https://www.scraperapi.com), usada como proxy para Fravega. Sin ella, Fravega se consulta directo y puede devolver 403 |
+| `MELI_CLIENT_ID`     | Sin uso      | Credencial OAuth de MercadoLibre. Sin efecto mientras la tienda esté en `DISABLED_STORES`                                                      |
+| `MELI_CLIENT_SECRET` | Sin uso      | Ídem                                                                                                                                           |
 
 > `CRON_SECRET` y `VERCEL_PROJECT_PRODUCTION_URL` los genera Vercel automáticamente.
 

--- a/src/scrapers/__tests__/index.test.ts
+++ b/src/scrapers/__tests__/index.test.ts
@@ -1,0 +1,31 @@
+import { scrapers, DISABLED_STORES } from "@/scrapers";
+
+describe("registro de scrapers", () => {
+  it("no expone las tiendas deshabilitadas", () => {
+    for (const store of DISABLED_STORES) {
+      expect(scrapers).not.toHaveProperty(store);
+    }
+  });
+
+  it("mantiene mercadolibre deshabilitado", () => {
+    expect(DISABLED_STORES).toContain("mercadolibre");
+  });
+
+  it("sigue exponiendo las tiendas activas", () => {
+    const activas = Object.keys(scrapers).filter((k) => k !== "default");
+
+    expect(activas).toEqual(
+      expect.arrayContaining([
+        "naldo",
+        "cetrogar",
+        "fravega",
+        "carrefour",
+        "oncity",
+      ]),
+    );
+  });
+
+  it("conserva el scraper por defecto que devuelve vacío", async () => {
+    await expect(scrapers.default("cualquier cosa")).resolves.toEqual([]);
+  });
+});

--- a/src/scrapers/index.ts
+++ b/src/scrapers/index.ts
@@ -3,17 +3,30 @@ import { scrapeNaldo } from "./naldo";
 import { scrapeCetrogar } from "./cetrogar";
 import { scrapeFravega } from "./fravega";
 import { scrapeCarrefour } from "./carrefour";
-import { scrapeMercadoLibre } from "./mercadolibre";
 import { scrapeOnCity } from "./oncity";
 
 type Scraper = (query: string) => Promise<Product[]>;
+
+/**
+ * Tiendas cuyo scraper existe pero no se ejecuta.
+ *
+ * Al quedar fuera de `scrapers` no corren, no fallan y no disparan las alertas
+ * de /api/health. El código del scraper se conserva para reactivarlas sin
+ * reescribirlas: alcanza con volver a agregarlas al registro de abajo.
+ *
+ * - mercadolibre: sus dos vías de acceso están cerradas. La API oficial responde
+ *   403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES incluso con un token OAuth válido
+ *   (ver src/platform/meli/token.ts), y el listado HTML está detrás de un
+ *   challenge de proof-of-work. Traerlo requiere los proxies premium de
+ *   ScraperAPI, que el plan actual no incluye.
+ */
+export const DISABLED_STORES = ["mercadolibre"] as const;
 
 export const scrapers: Record<string, Scraper> = {
   naldo: scrapeNaldo,
   cetrogar: scrapeCetrogar,
   fravega: scrapeFravega,
   carrefour: scrapeCarrefour,
-  mercadolibre: scrapeMercadoLibre,
   oncity: scrapeOnCity,
   default: async () => [],
 };


### PR DESCRIPTION
## Qué

Saca `mercadolibre` del registro de scrapers. El código del scraper y el módulo de token OAuth quedan en el árbol.

## Por qué

Las dos vías de acceso están cerradas, verificadas contra el sitio real:

- **API oficial**: devuelve `403 PA_UNAUTHORIZED_RESULT_FROM_POLICIES` incluso con un token OAuth `client_credentials` válido (el token funciona: `/users/me` responde 200). El bloqueo es del PolicyAgent, a nivel aplicación.
- **Listado HTML**: está detrás de un challenge de proof-of-work. Se descartaron con evidencia el bloqueo por IP, por headers y por cookies; lo que queda exige resolver el PoW (`_bmstate` → `_bmc`), que es evadir un control de acceso puesto a propósito.

Traerlo por un proveedor requiere los proxies premium de ScraperAPI. El plan actual es el gratuito (1000 créditos/mes, sin premium): `ultra_premium=true` responde `Your current plan does not allow you to use our premium proxies`.

Dejarlo en el registro tenía costo real: cada búsqueda esperaba a una tienda que siempre falla, y `/api/health` reportaba `degraded` en cada corrida del cron de 10 minutos, mandando un email cada vez.

## Cómo

- `DISABLED_STORES` en `src/scrapers/index.ts` documenta qué scrapers se conservan pero no se ejecutan, y por qué.
- `StoreNamesEnum` mantiene su entrada `MercadoLibre`: el caché por tienda de 24h y los snapshots históricos todavía pueden devolver productos suyos, y sin el enum no renderizarían.
- Reactivarla es volver a agregar la línea al registro.

## Verificación

- 46 suites, 317 tests en verde
- `npm run lint` sin errores (queda el warning preexistente de `e2e/happy-path.spec.ts`)
- `npm run build` OK