### PR TITLE
fix(health): treat empty scraper results as a broken store

### DIFF
--- a/src/app/api/health-check/route.ts
+++ b/src/app/api/health-check/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { Resend } from "resend";
 
 type StoreStatus = {
-  status: "ok" | "slow" | "down";
+  status: "ok" | "slow" | "empty" | "down";
   latency: number;
   count: number;
   error?: string;
@@ -23,8 +23,17 @@ async function notifyEmail(payload: HealthPayload): Promise<void> {
 
   const rows = Object.entries(payload.stores)
     .map(([name, s]) => {
-      const icon = s.status === "ok" ? "✅" : s.status === "slow" ? "⚠️" : "❌";
-      const detail = s.error ? ` — ${s.error}` : ` (${s.latency}ms, ${s.count} resultados)`;
+      const icon =
+        s.status === "ok"
+          ? "✅"
+          : s.status === "slow"
+            ? "⚠️"
+            : s.status === "empty"
+              ? "📭"
+              : "❌";
+      const detail = s.error
+        ? ` — ${s.error}`
+        : ` (${s.latency}ms, ${s.count} resultados)`;
       return `<tr>
         <td style="padding:6px 12px">${icon} ${name}</td>
         <td style="padding:6px 12px">${s.status}${detail}</td>

--- a/src/app/api/health/__tests__/route.test.ts
+++ b/src/app/api/health/__tests__/route.test.ts
@@ -1,0 +1,99 @@
+/** @jest-environment node */
+
+jest.mock("@/scrapers", () => ({
+  scrapers: {},
+}));
+
+import { GET } from "../route";
+import { scrapers } from "@/scrapers";
+
+const mockScrapers = scrapers as Record<
+  string,
+  (query: string) => Promise<unknown[]>
+>;
+
+function setScrapers(map: Record<string, () => Promise<unknown[]>>): void {
+  for (const key of Object.keys(mockScrapers)) delete mockScrapers[key];
+  Object.assign(mockScrapers, map);
+}
+
+async function readBody(res: Response) {
+  return (await res.json()) as {
+    status: string;
+    stores: Record<string, { status: string; count: number; error?: string }>;
+  };
+}
+
+describe("GET /api/health", () => {
+  afterEach(() => setScrapers({}));
+
+  it("marca 'empty' a una tienda que resuelve sin resultados", async () => {
+    setScrapers({
+      fravega: async () => [{ id: 1 }],
+      naldo: async () => [],
+    });
+
+    const body = await readBody(await GET());
+
+    expect(body.stores.fravega.status).toBe("ok");
+    expect(body.stores.naldo.status).toBe("empty");
+    expect(body.stores.naldo.count).toBe(0);
+  });
+
+  it("degrada el estado general cuando una tienda viene vacía", async () => {
+    setScrapers({
+      fravega: async () => [{ id: 1 }],
+      naldo: async () => [],
+    });
+
+    const res = await GET();
+    const body = await readBody(res);
+
+    expect(body.status).toBe("degraded");
+    expect(res.status).toBe(200);
+  });
+
+  it("reporta 'down' con 503 cuando todas las tiendas vienen vacías o caídas", async () => {
+    setScrapers({
+      naldo: async () => [],
+      fravega: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const res = await GET();
+    const body = await readBody(res);
+
+    expect(body.status).toBe("down");
+    expect(res.status).toBe(503);
+  });
+
+  it("reporta 'ok' cuando todas las tiendas traen resultados", async () => {
+    setScrapers({
+      fravega: async () => [{ id: 1 }],
+      naldo: async () => [{ id: 2 }],
+    });
+
+    const res = await GET();
+    const body = await readBody(res);
+
+    expect(body.status).toBe("ok");
+    expect(res.status).toBe(200);
+  });
+
+  it("distingue una tienda que lanza (down) de una vacía (empty)", async () => {
+    setScrapers({
+      caida: async () => {
+        throw new Error("timeout");
+      },
+      vacia: async () => [],
+    });
+
+    const body = await readBody(await GET());
+
+    expect(body.stores.caida.status).toBe("down");
+    expect(body.stores.caida.error).toBe("timeout");
+    expect(body.stores.vacia.status).toBe("empty");
+    expect(body.stores.vacia.error).toBeUndefined();
+  });
+});

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -5,7 +5,7 @@ const PROBE_QUERY = "smart tv";
 const TIMEOUT_MS = 8_000;
 
 type StoreStatus = {
-  status: "ok" | "slow" | "down";
+  status: "ok" | "slow" | "empty" | "down";
   latency: number;
   count: number;
   error?: string;
@@ -13,17 +13,25 @@ type StoreStatus = {
 
 async function probeStore(name: string): Promise<StoreStatus> {
   const scraper = scrapers[name];
-  if (!scraper) return { status: "down", latency: 0, count: 0, error: "not found" };
+  if (!scraper)
+    return { status: "down", latency: 0, count: 0, error: "not found" };
 
   const start = Date.now();
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const result = await Promise.race([
       scraper(PROBE_QUERY),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error("timeout")), TIMEOUT_MS),
-      ),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("timeout")), TIMEOUT_MS);
+      }),
     ]);
     const latency = Date.now() - start;
+    // La query de sondeo ("smart tv") siempre debería traer resultados: una
+    // lista vacía sin excepción significa que el scraper se rompió en silencio
+    // (cambió el HTML, la API devuelve otra forma), no que no haya stock.
+    if (result.length === 0) {
+      return { status: "empty", latency, count: 0 };
+    }
     return {
       status: latency > TIMEOUT_MS * 0.8 ? "slow" : "ok",
       latency,
@@ -36,6 +44,8 @@ async function probeStore(name: string): Promise<StoreStatus> {
       count: 0,
       error: err instanceof Error ? err.message : "unknown",
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 }
 
@@ -55,12 +65,14 @@ export async function GET() {
   }
 
   const statuses = Object.values(stores).map((s) => s.status);
-  const overallStatus =
-    statuses.every((s) => s === "ok")
-      ? "ok"
-      : statuses.every((s) => s === "down")
-        ? "down"
-        : "degraded";
+  // "empty" es una tienda rota: cuenta como caída para el estado general. Si
+  // todas vienen vacías o caídas, el servicio está down (503); si solo algunas,
+  // degraded — en ambos casos health-check dispara la alerta por email.
+  const overallStatus = statuses.every((s) => s === "ok")
+    ? "ok"
+    : statuses.every((s) => s === "down" || s === "empty")
+      ? "down"
+      : "degraded";
 
   const httpStatus = overallStatus === "down" ? 503 : 200;
 


### PR DESCRIPTION
## Qué

`/api/health` ahora distingue una tienda que devuelve **cero resultados** de una sana. Nuevo estado `empty`, separado de `down`.

## Por qué

`probeStore` reportaba `ok` con solo que el scraper resolviera sin lanzar excepción — aunque devolviera `[]`. La query de sondeo es `"smart tv"`, que siempre debería traer resultados; una lista vacía significa que el scraper se rompió en silencio (cambió el HTML, cambió la forma de la API), no que no haya stock.

El cron `/api/health-check` lee este endpoint y solo alerta cuando `status !== "ok"`. Con el comportamiento viejo, una tienda que empezaba a devolver vacío pasaba por sana y nadie se enteraba.

## Cómo

- `empty` cuenta como tienda rota para el estado general: `degraded` si solo algunas vienen vacías/caídas, `down` (503) si todas. En ambos casos el mail de alerta se dispara.
- El email marca las tiendas `empty` con un ícono propio (📭) para distinguirlas de las caídas (❌).
- De paso: se limpia el `setTimeout` del timeout en el camino exitoso. Antes, cuando el scraper ganaba la carrera, el timer quedaba colgado reteniendo el event loop 8s (se veía como un open handle en Jest).

## Verificación

- 47 suites, 322 tests en verde (5 nuevos para `/api/health`, que antes no tenía cobertura)
- `npm run lint` sin errores (queda el warning preexistente de `e2e/happy-path.spec.ts`)
- `npm run build` OK